### PR TITLE
#57 Long string fixes

### DIFF
--- a/src/AutogrowTextArea.tsx
+++ b/src/AutogrowTextArea.tsx
@@ -36,7 +36,7 @@ export const AutogrowTextArea: React.FC<TextAreaProps> = ({
   return (
     <div style={{ display: 'grid' }}>
       <textarea
-        id={name}
+        id={`${name}_textarea`}
         style={{
           height: 'auto',
           gridArea: '1 / 1 / 2 / 2',
@@ -47,7 +47,7 @@ export const AutogrowTextArea: React.FC<TextAreaProps> = ({
         }}
         rows={1}
         className={className}
-        name={name}
+        name={`${name}_textarea`}
         value={value}
         onChange={(e) => setValue(e.target.value)}
         autoFocus

--- a/src/CollapseProvider.tsx
+++ b/src/CollapseProvider.tsx
@@ -9,17 +9,22 @@ interface CollapseContext {
   collapseState: CollapseAllState | null
   setCollapseState: React.Dispatch<React.SetStateAction<CollapseAllState | null>>
   doesPathMatch: (path: CollectionKey[]) => boolean
+  currentlyEditingElement: string | null
+  setCurrentlyEditingElement: React.Dispatch<React.SetStateAction<string | null>>
 }
 const initialContext: CollapseContext = {
   collapseState: null,
   setCollapseState: () => {},
   doesPathMatch: () => false,
+  currentlyEditingElement: null,
+  setCurrentlyEditingElement: () => {},
 }
 
 const CollapseProviderContext = createContext(initialContext)
 
 export const CollapseProvider = ({ children }: { children: React.ReactNode }) => {
   const [collapseState, setCollapseState] = useState<CollapseAllState | null>(null)
+  const [currentlyEditingElement, setCurrentlyEditingElement] = useState<string | null>(null)
 
   const doesPathMatch = (path: CollectionKey[]) => {
     if (collapseState === null) return false
@@ -32,7 +37,15 @@ export const CollapseProvider = ({ children }: { children: React.ReactNode }) =>
   }
 
   return (
-    <CollapseProviderContext.Provider value={{ collapseState, setCollapseState, doesPathMatch }}>
+    <CollapseProviderContext.Provider
+      value={{
+        collapseState,
+        setCollapseState,
+        doesPathMatch,
+        currentlyEditingElement,
+        setCurrentlyEditingElement,
+      }}
+    >
       {children}
     </CollapseProviderContext.Provider>
   )

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -14,7 +14,7 @@ import { filterNode, isCollection } from './filterHelpers'
 import './style.css'
 import { AutogrowTextArea } from './AutogrowTextArea'
 import { useTheme } from './theme'
-import { useCollapseAll } from './CollapseProvider'
+import { useCollapseAll } from './TreeStateProvider'
 import { toPathString } from './ValueNodes'
 
 export const CollectionNode: React.FC<CollectionNodeProps> = ({

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -226,8 +226,10 @@ export const CollectionNode: React.FC<CollectionNodeProps> = ({
   }
 
   // A crude measure to estimate the approximate height of the block, for
-  // setting the max-height in the collapsible interior
-  const numOfLines = JSON.stringify(data, null, 2).split('\n').length
+  // setting the max-height in the collapsible interior.
+  // The Regexp replacement is so we can parse escaped line breaks *within* the
+  // JSON into *actual* line breaks before splitting
+  const numOfLines = JSON.stringify(data, null, 2).replace(/\\n/g, '\n').split('\n').length
 
   const CollectionChildren = !hasBeenOpened.current ? null : !isEditing ? (
     keyValueArray.map(([key, value], index) => {

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -51,7 +51,6 @@ export const CollectionNode: React.FC<CollectionNodeProps> = ({
     translate,
     customNodeDefinitions,
   } = props
-  const [isEditingKey, setIsEditingKey] = useState(false)
   const [stringifiedValue, setStringifiedValue] = useState(JSON.stringify(data, null, 2))
   const [error, setError] = useState<string | null>(null)
 
@@ -169,7 +168,7 @@ export const CollectionNode: React.FC<CollectionNodeProps> = ({
   }
 
   const handleEditKey = (newKey: string) => {
-    setIsEditingKey(false)
+    setCurrentlyEditingElement(null)
     if (name === newKey) return
     if (!parentData) return
     const parentPath = path.slice(0, -1)
@@ -214,13 +213,13 @@ export const CollectionNode: React.FC<CollectionNodeProps> = ({
 
   const handleCancel = () => {
     setCurrentlyEditingElement(null)
-    setIsEditingKey(false)
     setError(null)
     setStringifiedValue(JSON.stringify(data, null, 2))
   }
 
   // DERIVED VALUES (this makes the render logic easier to understand)
   const isEditing = currentlyEditingElement === pathString
+  const isEditingKey = currentlyEditingElement === `key_${pathString}`
   const isArray = typeof path.slice(-1)[0] === 'number'
   const showLabel = showArrayIndices || !isArray
   const showCount = showCollectionCount === 'when-closed' ? collapsed : showCollectionCount
@@ -350,7 +349,7 @@ export const CollectionNode: React.FC<CollectionNodeProps> = ({
   ) : (
     <span
       style={getStyles('property', nodeData)}
-      onDoubleClick={() => canEditKey && setIsEditingKey(true)}
+      onDoubleClick={() => canEditKey && setCurrentlyEditingElement(`key_${pathString}`)}
     >
       {showKey ? `${name}:` : null}
     </span>

--- a/src/JsonEditor.tsx
+++ b/src/JsonEditor.tsx
@@ -12,7 +12,7 @@ import {
   type SearchFilterFunction,
 } from './types'
 import { useTheme, ThemeProvider } from './theme'
-import { CollapseProvider, useCollapseAll } from './TreeStateProvider'
+import { TreeStateProvider, useTreeState } from './TreeStateProvider'
 import { getTranslateFunction } from './localisation'
 import './style.css'
 import { ValueNodeWrapper } from './ValueNodeWrapper'
@@ -54,7 +54,7 @@ const Editor: React.FC<JsonEditorProps> = ({
   customNodeDefinitions = [],
 }) => {
   const { getStyles, setTheme, setIcons } = useTheme()
-  const { setCollapseState } = useCollapseAll()
+  const { setCollapseState } = useTreeState()
   const collapseFilter = useCallback(getFilterFunction(collapse), [collapse])
   const translate = useCallback(getTranslateFunction(translations, customText), [
     translations,
@@ -212,9 +212,9 @@ const Editor: React.FC<JsonEditorProps> = ({
 
 const JsonEditor: React.FC<JsonEditorProps> = (props) => (
   <ThemeProvider>
-    <CollapseProvider>
+    <TreeStateProvider>
       <Editor {...props} />
-    </CollapseProvider>
+    </TreeStateProvider>
   </ThemeProvider>
 )
 

--- a/src/JsonEditor.tsx
+++ b/src/JsonEditor.tsx
@@ -12,7 +12,7 @@ import {
   type SearchFilterFunction,
 } from './types'
 import { useTheme, ThemeProvider } from './theme'
-import { CollapseProvider, useCollapseAll } from './CollapseProvider'
+import { CollapseProvider, useCollapseAll } from './TreeStateProvider'
 import { getTranslateFunction } from './localisation'
 import './style.css'
 import { ValueNodeWrapper } from './ValueNodeWrapper'

--- a/src/TreeStateProvider.tsx
+++ b/src/TreeStateProvider.tsx
@@ -20,7 +20,7 @@ const initialContext: CollapseContext = {
   setCurrentlyEditingElement: () => {},
 }
 
-const CollapseProviderContext = createContext(initialContext)
+const TreeStateProviderContext = createContext(initialContext)
 
 export const CollapseProvider = ({ children }: { children: React.ReactNode }) => {
   const [collapseState, setCollapseState] = useState<CollapseAllState | null>(null)
@@ -37,7 +37,7 @@ export const CollapseProvider = ({ children }: { children: React.ReactNode }) =>
   }
 
   return (
-    <CollapseProviderContext.Provider
+    <TreeStateProviderContext.Provider
       value={{
         collapseState,
         setCollapseState,
@@ -47,8 +47,8 @@ export const CollapseProvider = ({ children }: { children: React.ReactNode }) =>
       }}
     >
       {children}
-    </CollapseProviderContext.Provider>
+    </TreeStateProviderContext.Provider>
   )
 }
 
-export const useCollapseAll = () => useContext(CollapseProviderContext)
+export const useCollapseAll = () => useContext(TreeStateProviderContext)

--- a/src/TreeStateProvider.tsx
+++ b/src/TreeStateProvider.tsx
@@ -1,3 +1,8 @@
+/**
+ * Captures the collapse state and the editing state of the entire tree, as
+ * nodes sometimes need to know the state of other (sibling or child) nodes
+ */
+
 import React, { createContext, useContext, useState } from 'react'
 import { type CollectionKey } from './types'
 
@@ -5,24 +10,26 @@ interface CollapseAllState {
   path: CollectionKey[]
   open: boolean
 }
-interface CollapseContext {
+interface TreeStateContext {
   collapseState: CollapseAllState | null
   setCollapseState: React.Dispatch<React.SetStateAction<CollapseAllState | null>>
   doesPathMatch: (path: CollectionKey[]) => boolean
   currentlyEditingElement: string | null
   setCurrentlyEditingElement: React.Dispatch<React.SetStateAction<string | null>>
+  areChildrenBeingEdited: (pathString: string) => boolean
 }
-const initialContext: CollapseContext = {
+const initialContext: TreeStateContext = {
   collapseState: null,
   setCollapseState: () => {},
   doesPathMatch: () => false,
   currentlyEditingElement: null,
   setCurrentlyEditingElement: () => {},
+  areChildrenBeingEdited: () => false,
 }
 
 const TreeStateProviderContext = createContext(initialContext)
 
-export const CollapseProvider = ({ children }: { children: React.ReactNode }) => {
+export const TreeStateProvider = ({ children }: { children: React.ReactNode }) => {
   const [collapseState, setCollapseState] = useState<CollapseAllState | null>(null)
   const [currentlyEditingElement, setCurrentlyEditingElement] = useState<string | null>(null)
 
@@ -36,14 +43,20 @@ export const CollapseProvider = ({ children }: { children: React.ReactNode }) =>
     return true
   }
 
+  const areChildrenBeingEdited = (pathString: string) =>
+    currentlyEditingElement !== null && currentlyEditingElement.includes(pathString)
+
   return (
     <TreeStateProviderContext.Provider
       value={{
+        // Collapse
         collapseState,
         setCollapseState,
         doesPathMatch,
+        // Editing
         currentlyEditingElement,
         setCurrentlyEditingElement,
+        areChildrenBeingEdited,
       }}
     >
       {children}
@@ -51,4 +64,4 @@ export const CollapseProvider = ({ children }: { children: React.ReactNode }) =>
   )
 }
 
-export const useCollapseAll = () => useContext(TreeStateProviderContext)
+export const useTreeState = () => useContext(TreeStateProviderContext)

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -206,8 +206,15 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
     })
   }
 
+  // DERIVED VALUES (this makes the render logic easier to understand)
   const isArray = typeof path.slice(-1)[0] === 'number'
   const canEditKey = !isArray && canEdit && canDelete
+  const showError = !isEditing && error
+  const showTypeSelector = isEditing && allowedDataTypes.length > 0
+  const showEditButtons = dataType !== 'invalid' && !error && showEditTools
+  const showKeyEdit = showLabel && isEditingKey
+  const showKey = showLabel && !isEditingKey && !hideKey
+  const showCustomNode = CustomNode && ((isEditing && showOnEdit) || (!isEditing && showOnView))
 
   const inputProps = {
     value,
@@ -224,28 +231,27 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
     translate,
   }
 
-  const ValueComponent =
-    CustomNode && ((isEditing && showOnEdit) || (!isEditing && showOnView)) ? (
-      <CustomNode
-        {...props}
-        value={value}
-        customNodeProps={customNodeProps}
-        setValue={updateValue}
-        handleEdit={handleEdit}
-        handleCancel={handleCancel}
-        handleKeyPress={(e: React.KeyboardEvent) => {
-          if (e.key === 'Enter') handleEdit()
-          else if (e.key === 'Escape') handleCancel()
-        }}
-        isEditing={isEditing}
-        setIsEditing={() => setCurrentlyEditingElement(pathString)}
-        getStyles={getStyles}
-      />
-    ) : (
-      // Need to re-fetch data type to make sure it's one of the "core" ones
-      // when fetching a non-custom component
-      getInputComponent(getDataType(data) as DataType, inputProps)
-    )
+  const ValueComponent = showCustomNode ? (
+    <CustomNode
+      {...props}
+      value={value}
+      customNodeProps={customNodeProps}
+      setValue={updateValue}
+      handleEdit={handleEdit}
+      handleCancel={handleCancel}
+      handleKeyPress={(e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') handleEdit()
+        else if (e.key === 'Escape') handleCancel()
+      }}
+      isEditing={isEditing}
+      setIsEditing={() => setCurrentlyEditingElement(pathString)}
+      getStyles={getStyles}
+    />
+  ) : (
+    // Need to re-fetch data type to make sure it's one of the "core" ones
+    // when fetching a non-custom component
+    getInputComponent(getDataType(data) as DataType, inputProps)
+  )
 
   return (
     <div className="jer-component jer-value-component" style={{ marginLeft: `${indent / 2}em` }}>
@@ -255,7 +261,7 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
           flexWrap: (name as string).length > 10 ? 'wrap' : 'nowrap',
         }}
       >
-        {showLabel && !isEditingKey && !hideKey && (
+        {showKey && (
           <span
             className="jer-object-key"
             style={{
@@ -268,7 +274,7 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
             {name}:{' '}
           </span>
         )}
-        {showLabel && isEditingKey && (
+        {showKeyEdit && (
           <input
             className="jer-object-key"
             type="text"
@@ -285,9 +291,7 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
           {isEditing ? (
             <InputButtons onOk={handleEdit} onCancel={handleCancel} nodeData={nodeData} />
           ) : (
-            dataType !== 'invalid' &&
-            !error &&
-            showEditTools && (
+            showEditButtons && (
               <EditButtons
                 startEdit={canEdit ? () => setCurrentlyEditingElement(pathString) : undefined}
                 handleDelete={canDelete ? handleDelete : undefined}
@@ -297,7 +301,7 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
               />
             )
           )}
-          {isEditing && allowedDataTypes.length > 0 && (
+          {showTypeSelector && (
             <div className="jer-select">
               <select
                 name={`${name}-type-select`}
@@ -314,7 +318,7 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
               <span className="focus"></span>
             </div>
           )}
-          {!isEditing && error && (
+          {showError && (
             <span className="jer-error-slug" style={getStyles('error', nodeData)}>
               {error}
             </span>

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -50,7 +50,6 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
   } = props
   const { getStyles } = useTheme()
   const { currentlyEditingElement, setCurrentlyEditingElement } = useTreeState()
-  const [isEditingKey, setIsEditingKey] = useState(false)
   const [value, setValue] = useState<typeof data | CollectionData>(
     // Bad things happen when you put a function into useState
     typeof data === 'function' ? INVALID_FUNCTION_STRING : data
@@ -63,7 +62,6 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
   const [dataType, setDataType] = useState<DataType | string>(getDataType(data, customNodeData))
 
   const pathString = toPathString(path)
-  const isEditing = currentlyEditingElement === pathString
 
   const updateValue = useCallback(
     (newValue: ValueData) => {
@@ -175,7 +173,7 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
   }
 
   const handleEditKey = (newKey: string) => {
-    setIsEditingKey(false)
+    setCurrentlyEditingElement(null)
     if (name === newKey) return
     if (!parentData) return
     const parentPath = path.slice(0, -1)
@@ -195,7 +193,6 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
 
   const handleCancel = () => {
     setCurrentlyEditingElement(null)
-    setIsEditingKey(false)
     setValue(data)
     setDataType(getDataType(data, customNodeData))
   }
@@ -207,6 +204,8 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
   }
 
   // DERIVED VALUES (this makes the render logic easier to understand)
+  const isEditing = currentlyEditingElement === pathString
+  const isEditingKey = currentlyEditingElement === `key_${pathString}`
   const isArray = typeof path.slice(-1)[0] === 'number'
   const canEditKey = !isArray && canEdit && canDelete
   const showError = !isEditing && error
@@ -269,7 +268,7 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
               minWidth: `${Math.min(String(name).length + 1, 5)}ch`,
               flexShrink: (name as string).length > 10 ? 1 : 0,
             }}
-            onDoubleClick={() => canEditKey && setIsEditingKey(true)}
+            onDoubleClick={() => canEditKey && setCurrentlyEditingElement(`key_${pathString}`)}
           >
             {name}:{' '}
           </span>

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -25,7 +25,7 @@ import { useTheme } from './theme'
 import './style.css'
 import { getCustomNode, type CustomNodeData } from './CustomNode'
 import { filterNode } from './filterHelpers'
-import { useCollapseAll } from './CollapseProvider'
+import { useCollapseAll } from './TreeStateProvider'
 
 export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
   const {

--- a/src/ValueNodes.tsx
+++ b/src/ValueNodes.tsx
@@ -12,6 +12,8 @@ export const INVALID_FUNCTION_STRING = '**INVALID_FUNCTION**'
 export const truncate = (string: string, length = 200) =>
   string.length < length ? string : `${string.slice(0, length - 2).trim()}...`
 
+export const toPathString = (path: Array<string | number>) => path.join('.').replace(/"/g, '_')
+
 export const StringValue: React.FC<InputProps & { value: string }> = ({
   value,
   setValue,
@@ -29,13 +31,14 @@ export const StringValue: React.FC<InputProps & { value: string }> = ({
     if (e.key === 'Enter' && !e.shiftKey) handleEdit()
     else if (e.key === 'Escape') handleCancel()
   }
+  const pathString = toPathString(path)
 
   const quoteChar = showStringQuotes ? '"' : ''
 
   return isEditing ? (
     <AutogrowTextArea
       className="jer-input-text"
-      name={path.join('.')}
+      name={pathString}
       value={value}
       setValue={setValue as React.Dispatch<React.SetStateAction<string>>}
       isEditing={isEditing}
@@ -44,7 +47,7 @@ export const StringValue: React.FC<InputProps & { value: string }> = ({
     />
   ) : (
     <div
-      id={`${path.join('.')}_display`}
+      id={`${pathString}_display`}
       onDoubleClick={() => setIsEditing(true)}
       onClick={(e) => {
         if (e.getModifierState('Control') || e.getModifierState('Meta')) setIsEditing(true)
@@ -96,7 +99,7 @@ export const NumberValue: React.FC<InputProps & { value: number }> = ({
     <input
       className="jer-input-number"
       type="text"
-      name={path.join('.')}
+      name={toPathString(path)}
       value={value}
       onChange={(e) => setValue(validateNumber(e.target.value))}
       autoFocus
@@ -142,7 +145,7 @@ export const BooleanValue: React.FC<InputProps & { value: boolean }> = ({
     <input
       className="jer-input-boolean"
       type="checkbox"
-      name={path.join('.')}
+      name={toPathString(path)}
       checked={value}
       onChange={() => setValue(!value)}
     />

--- a/src/ValueNodes.tsx
+++ b/src/ValueNodes.tsx
@@ -30,6 +30,8 @@ export const StringValue: React.FC<InputProps & { value: string }> = ({
     else if (e.key === 'Escape') handleCancel()
   }
 
+  const quoteChar = showStringQuotes ? '"' : ''
+
   return isEditing ? (
     <AutogrowTextArea
       className="jer-input-text"
@@ -42,6 +44,7 @@ export const StringValue: React.FC<InputProps & { value: string }> = ({
     />
   ) : (
     <div
+      id={`${path.join('.')}_display`}
       onDoubleClick={() => setIsEditing(true)}
       onClick={(e) => {
         if (e.getModifierState('Control') || e.getModifierState('Meta')) setIsEditing(true)
@@ -49,9 +52,9 @@ export const StringValue: React.FC<InputProps & { value: string }> = ({
       className="jer-value-string"
       style={getStyles('string', nodeData)}
     >
-      {showStringQuotes ? '"' : ''}
+      {quoteChar}
       {truncate(value, stringTruncate)}
-      {showStringQuotes ? '"' : ''}
+      {quoteChar}
     </div>
   )
 }

--- a/src/style.css
+++ b/src/style.css
@@ -238,7 +238,7 @@ select:focus + .focus {
   padding-bottom: 0.2em;
   min-width: 6em;
   overflow: hidden;
-  max-height: 30em;
+  /* max-height: 20em; */
 }
 
 .jer-value-number {

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -138,6 +138,7 @@ export const themes: Record<ThemeName, Theme> = {
       number: ['darkBlue', { fontSize: '85%' }],
       boolean: ['mid', { fontStyle: 'italic', fontWeight: 'bold', fontSize: '80%' }],
       null: ['#cccccc', { fontWeight: 'bold' }],
+      input: { border: '1px solid rgb(115, 194, 198)' },
       iconCollection: '#1D3557',
       iconEdit: '#457B9D',
       iconDelete: '#E63946',


### PR DESCRIPTION
Fix #57 

Also adds restriction so that only one element can be edited at a time (this makes it easier to handle the original problem).

The tricky thing was getting a parent collection to know when one of its children is being edited (so it can change its auto-height logic). So I've added the currently-editing element to a global state provider (it already tracks "Collapse" state).
