### PR TITLE
Handle missing "navigator.clipboard"

### DIFF
--- a/src/ButtonPanels.tsx
+++ b/src/ButtonPanels.tsx
@@ -79,10 +79,10 @@ export const EditButtons: React.FC<EditButtonProps> = ({
         value = data
         stringValue = type ? JSON.stringify(data, null, 2) : String(value)
       }
-      void navigator.clipboard.writeText(stringValue)
-    }
-    if (typeof enableClipboard === 'function') {
-      enableClipboard({ value, stringValue, path, key, type: copyType })
+      void navigator.clipboard?.writeText(stringValue)
+      if (typeof enableClipboard === 'function') {
+        enableClipboard({ value, stringValue, path, key, type: copyType })
+      }
     }
   }
 


### PR DESCRIPTION
In some cases navigator.clipboard can be undefined. For example on HTTP site (happens in DMZ environments).

In such cases copy will fail. However, it can always be remediated on user side by using good old execCommand. 

This commit modifies code to avoid exception on copy.