### PR TITLE
Fix missing colon when key is integer 0

### DIFF
--- a/src/hooks/useCommon.ts
+++ b/src/hooks/useCommon.ts
@@ -39,7 +39,8 @@ export const useCommon = ({ props, collapsed }: CommonProps) => {
   const [error, setError] = useState<string | null>(null)
 
   const nodeData = { ...incomingNodeData, collapsed }
-  const { path, key: name, size } = nodeData
+  const { path, key, size } = nodeData
+  const name = key + ''
 
   const pathString = toPathString(path)
 


### PR DESCRIPTION
Hey, thanks for the great library!

I noticed a bug, actually visible on the project's home page right now. When the JSON key is 0, the colon is not rendered.

![capture](https://github.com/user-attachments/assets/13fa27f3-44f3-4491-b9a4-711db6452277)

It looks like the ternary here goes to the falsy branch since 0 is falsy:
https://github.com/CarlosNZ/json-edit-react/blob/f98acae308b61938b77592d9dd823fd16e5ef61a/src/KeyDisplay.tsx#L58

I saw that the `name` prop is eventually casted to `string`, but its original type is a `CollectionKey` which is `string | number`. So I thought this change is safe to make, but I know it might not be ideal.