### PR TITLE
Fix: preserve in-progress JSON5 edit text on parent re-render

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,7 @@ This component is heavily inspired by [react-json-view](https://github.com/mac-s
 
 ## Changelog
 
+- **1.29.1**: Squashed a bug where a parent re-render would revert data mid-edit when editing a whole collection as text ([#234](https://github.com/CarlosNZ/json-edit-react/pull/234))
 - **1.29.0**: Option to display array indexes starting at "1" ([#62](https://github.com/CarlosNZ/json-edit-react/issues/62))
 - **1.28.2**: When switching data type, only keep editing if new type is primitive ([#216](https://github.com/CarlosNZ/json-edit-react/issues/216))
 - **1.28.1**: Fix left padding of root node when value is primitive ([#214](https://github.com/CarlosNZ/json-edit-react/issues/214))

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -117,7 +117,10 @@ export const CollectionNode: React.FC<CollectionNodeProps> = (props) => {
   useEffect(() => {
     setStringifiedValue(jsonStringify(data))
     // if (isEditing) setCurrentlyEditingElement(null)
-  }, [data, jsonStringify])
+    // jsonStringify is a serializer, not a trigger — including it here would
+    // reset in-progress edit text on every parent re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
 
   useEffect(() => {
     const shouldBeCollapsed = collapseFilter(nodeData) && !isEditing

--- a/src/JsonEditor.tsx
+++ b/src/JsonEditor.tsx
@@ -35,6 +35,13 @@ import { ValueNodeWrapper } from './ValueNodeWrapper'
 import './style.css'
 import { getCustomNode } from './CustomNode'
 
+// Module-scoped so the default is a stable reference across renders;
+// an inline default would clobber in-progress edits in CollectionNode.
+const defaultJsonStringify = (
+  data: JsonData,
+  replacer?: (key: string, value: unknown) => unknown
+) => JSON.stringify(data, replacer, 2)
+
 const Editor: React.FC<JsonEditorProps> = ({
   data: srcData,
   setData: srcSetData,
@@ -79,7 +86,7 @@ const Editor: React.FC<JsonEditorProps> = ({
   customNodeDefinitions = [],
   customButtons = [],
   jsonParse = JSON.parse,
-  jsonStringify = (data, replacer) => JSON.stringify(data, replacer, 2),
+  jsonStringify = defaultJsonStringify,
   TextEditor,
   errorMessageTimeout = 2500,
   keyboardControls = {},


### PR DESCRIPTION
## Problem

When editing an object or array in edit-as-JSON5 mode, any in-progress textarea text would revert to the committed value whenever the parent component re-rendered — even when `data` and all props passed to `<JsonEditor>` were referentially stable. Leaf primitive editing was unaffected.

Root cause: the default `jsonStringify` in `JsonEditor` was an inline arrow function expression in the destructured props, so a fresh function reference was created on every render. That cascaded through `jsonStringifyReplacement` (memoized on `jsonStringify`) and into `CollectionNode`'s resync effect, whose dep array contained `jsonStringify`. The effect re-fired on every parent render and called `setStringifiedValue(jsonStringify(data))`, clobbering the user's text.

## Fix

- Hoist the default `jsonStringify` to module scope so the reference is stable across renders.
- Remove `jsonStringify` from `CollectionNode`'s resync `useEffect` deps. It's a serializer used inside the effect, not a trigger; the serializer changing should not re-stringify mid-edit. This also defends against consumers passing an unmemoized custom `jsonStringify`.

## Test plan

- [x] Run the demo (`yarn dev` from repo root, ensure Vite logs `local`). Begin editing an object/array as JSON5, then toggle any options checkbox to force a parent re-render — in-progress text should survive.
- [x] Regression: leaf primitive editing still survives parent re-renders.
- [x] Regression: commit (Enter / OK) and cancel (Esc) still behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)