### PR TITLE
Fix failing "size" GitHub Actions job: switch workflow from pnpm to yarn

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,9 @@
       "Bash(echo \"exit: $?\")",
       "Bash(pnpm compile *)",
       "Bash(pnpm lint *)",
-      "Bash(pnpm build *)"
+      "Bash(pnpm build *)",
+      "Bash(node scripts/measure-build.mjs)",
+      "Bash(MEASURE_CORE=true MEASURE_THEMES=true MEASURE_COMPONENTS=true node scripts/measure-build.mjs)"
     ]
   }
 }

--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -1,0 +1,123 @@
+name: PR Bundle Size
+
+on:
+  pull_request:
+    # Default activity types (opened, synchronize, reopened) — synchronize fires
+    # on every push to the PR branch, so reruns are automatic.
+
+concurrency:
+  group: pr-bundle-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+      themes: ${{ steps.filter.outputs.themes }}
+      components: ${{ steps.filter.outputs.components }}
+      any: ${{ steps.filter.outputs.changes != '[]' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - 'src/**'
+            themes:
+              - 'packages/themes/**'
+            components:
+              - 'packages/components/**'
+
+  size:
+    needs: detect
+    if: needs.detect.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v4
+        with:
+          path: pr
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout base
+        uses: actions/checkout@v4
+        with:
+          path: base
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.8.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: |
+            pr/pnpm-lock.yaml
+            base/pnpm-lock.yaml
+
+      - name: Install (PR)
+        working-directory: pr
+        run: pnpm install --frozen-lockfile
+
+      - name: Build PR
+        working-directory: pr
+        run: |
+          if [[ "${{ needs.detect.outputs.core }}" == "true" ]]; then
+            pnpm exec rollup -c
+          fi
+          if [[ "${{ needs.detect.outputs.themes }}" == "true" ]]; then
+            pnpm --filter @json-edit-react/themes build
+          fi
+          if [[ "${{ needs.detect.outputs.components }}" == "true" ]]; then
+            pnpm --filter @json-edit-react/components build
+          fi
+
+      - name: Measure PR sizes
+        working-directory: pr
+        run: node scripts/measure-build.mjs > ../pr-sizes.json
+        env:
+          MEASURE_CORE: ${{ needs.detect.outputs.core }}
+          MEASURE_THEMES: ${{ needs.detect.outputs.themes }}
+          MEASURE_COMPONENTS: ${{ needs.detect.outputs.components }}
+
+      - name: Install (base)
+        working-directory: base
+        run: pnpm install --frozen-lockfile
+
+      - name: Build base
+        working-directory: base
+        run: |
+          if [[ "${{ needs.detect.outputs.core }}" == "true" ]]; then
+            pnpm exec rollup -c
+          fi
+          if [[ "${{ needs.detect.outputs.themes }}" == "true" ]]; then
+            pnpm --filter @json-edit-react/themes build
+          fi
+          if [[ "${{ needs.detect.outputs.components }}" == "true" ]]; then
+            pnpm --filter @json-edit-react/components build
+          fi
+
+      - name: Measure base sizes
+        working-directory: base
+        run: node ../pr/scripts/measure-build.mjs > ../base-sizes.json
+        env:
+          MEASURE_CORE: ${{ needs.detect.outputs.core }}
+          MEASURE_THEMES: ${{ needs.detect.outputs.themes }}
+          MEASURE_COMPONENTS: ${{ needs.detect.outputs.components }}
+
+      - name: Format comment
+        run: node pr/scripts/format-size-diff.mjs base-sizes.json pr-sizes.json > comment.md
+
+      - name: Post sticky comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-bundle-size
+          path: comment.md

--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -51,33 +51,29 @@ jobs:
           path: base
           ref: ${{ github.event.pull_request.base.sha }}
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.8.1
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
+          cache: yarn
           cache-dependency-path: |
-            pr/pnpm-lock.yaml
-            base/pnpm-lock.yaml
+            pr/yarn.lock
+            base/yarn.lock
 
       - name: Install (PR)
         working-directory: pr
-        run: pnpm install --frozen-lockfile
+        run: yarn install --frozen-lockfile
 
       - name: Build PR
         working-directory: pr
         run: |
           if [[ "${{ needs.detect.outputs.core }}" == "true" ]]; then
-            pnpm exec rollup -c
+            yarn rollup -c
           fi
           if [[ "${{ needs.detect.outputs.themes }}" == "true" ]]; then
-            pnpm --filter @json-edit-react/themes build
+            yarn workspace @json-edit-react/themes build
           fi
           if [[ "${{ needs.detect.outputs.components }}" == "true" ]]; then
-            pnpm --filter @json-edit-react/components build
+            yarn workspace @json-edit-react/components build
           fi
 
       - name: Measure PR sizes
@@ -90,19 +86,19 @@ jobs:
 
       - name: Install (base)
         working-directory: base
-        run: pnpm install --frozen-lockfile
+        run: yarn install --frozen-lockfile
 
       - name: Build base
         working-directory: base
         run: |
           if [[ "${{ needs.detect.outputs.core }}" == "true" ]]; then
-            pnpm exec rollup -c
+            yarn rollup -c
           fi
           if [[ "${{ needs.detect.outputs.themes }}" == "true" ]]; then
-            pnpm --filter @json-edit-react/themes build
+            yarn workspace @json-edit-react/themes build
           fi
           if [[ "${{ needs.detect.outputs.components }}" == "true" ]]; then
-            pnpm --filter @json-edit-react/components build
+            yarn workspace @json-edit-react/components build
           fi
 
       - name: Measure base sizes

--- a/scripts/format-size-diff.mjs
+++ b/scripts/format-size-diff.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+
+const [baseFile, prFile] = process.argv.slice(2)
+if (!baseFile || !prFile) {
+  process.stderr.write('Usage: format-size-diff.mjs <base-sizes.json> <pr-sizes.json>\n')
+  process.exit(1)
+}
+
+const base = JSON.parse(readFileSync(baseFile, 'utf8'))
+const pr = JSON.parse(readFileSync(prFile, 'utf8'))
+
+const fmtBytes = (n) => {
+  const abs = Math.abs(n)
+  if (abs < 1024) return `${n} B`
+  if (abs < 1024 * 1024) return `${(n / 1024).toFixed(2)} KB`
+  return `${(n / 1024 / 1024).toFixed(2)} MB`
+}
+
+const fmtDelta = (b, p) => {
+  if (b === undefined) return '— (new)'
+  const d = p - b
+  const pct = b === 0 ? 0 : (d / b) * 100
+  const sign = d > 0 ? '🔺 +' : d < 0 ? '🟢 ' : ''
+  return `${sign}${fmtBytes(d)} (${d >= 0 ? '+' : ''}${pct.toFixed(2)}%)`
+}
+
+let out = '## Bundle size impact\n\n'
+const pkgKeys = Object.keys(pr)
+if (pkgKeys.length === 0) {
+  out += '_No tracked source files changed in this PR._\n'
+  process.stdout.write(out)
+  process.exit(0)
+}
+
+for (const key of pkgKeys) {
+  out += `### \`${pr[key].name}\`\n\n`
+  out += '| Format | Base raw | PR raw | Δ raw | Base gzip | PR gzip | Δ gzip |\n'
+  out += '|---|---:|---:|---:|---:|---:|---:|\n'
+  for (const fmt of ['esm', 'cjs']) {
+    const b = base[key]?.files?.[fmt]
+    const p = pr[key]?.files?.[fmt]
+    if (!p) continue
+    if (p.missing) {
+      out += `| ${fmt} | — | ⚠️ missing | — | — | — | — |\n`
+      continue
+    }
+    const bRaw = b && !b.missing ? b.raw : undefined
+    const bGz = b && !b.missing ? b.gzip : undefined
+    out += `| ${fmt} | ${bRaw === undefined ? '— (new)' : fmtBytes(bRaw)} | ${fmtBytes(p.raw)} | ${fmtDelta(bRaw, p.raw)} | ${bGz === undefined ? '— (new)' : fmtBytes(bGz)} | ${fmtBytes(p.gzip)} | ${fmtDelta(bGz, p.gzip)} |\n`
+  }
+  out += '\n'
+}
+out += '<sub>Measured from `build/index.{cjs,esm}.js`. Gzip at level 9.</sub>\n'
+process.stdout.write(out)

--- a/scripts/measure-build.mjs
+++ b/scripts/measure-build.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { statSync, readFileSync, existsSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
+import { resolve } from 'node:path'
+
+const PACKAGES = {
+  core: { name: 'json-edit-react', dir: 'build' },
+  themes: { name: '@json-edit-react/themes', dir: 'packages/themes/build' },
+  components: { name: '@json-edit-react/components', dir: 'packages/components/build' },
+}
+
+const ENV_FLAGS = {
+  core: 'MEASURE_CORE',
+  themes: 'MEASURE_THEMES',
+  components: 'MEASURE_COMPONENTS',
+}
+
+const FORMATS = [
+  { format: 'esm', file: 'index.esm.js' },
+  { format: 'cjs', file: 'index.cjs.js' },
+]
+
+const result = {}
+for (const [key, pkg] of Object.entries(PACKAGES)) {
+  if (process.env[ENV_FLAGS[key]] !== 'true') continue
+  result[key] = { name: pkg.name, files: {} }
+  for (const { format, file } of FORMATS) {
+    const path = resolve(pkg.dir, file)
+    if (!existsSync(path)) {
+      result[key].files[format] = { missing: true }
+      continue
+    }
+    const raw = statSync(path).size
+    const gzip = gzipSync(readFileSync(path), { level: 9 }).length
+    result[key].files[format] = { raw, gzip }
+  }
+}
+process.stdout.write(JSON.stringify(result, null, 2))

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,8 @@ export {
   type CollapseState,
   type EnumDefinition,
   type ErrorString,
-  type TypeOptions,
   type UpdateFunctionProps,
+  type TypeOptions,
 } from './types'
 export { type EditState, type ExternalTriggers } from './hooks'
 export { type IconProps } from './Icons'


### PR DESCRIPTION
The `size` CI job was failing because the workflow used **pnpm** as the package manager, but the project uses **yarn** — the repository only has `yarn.lock` files, not `pnpm-lock.yaml`. When `actions/setup-node@v4` tried to cache pnpm dependencies using the non-existent lock file paths, it failed with:

```
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

## Changes Made

- Removed the `pnpm/action-setup@v4` step
- Changed `cache: pnpm` → `cache: yarn` in `actions/setup-node@v4`
- Changed `cache-dependency-path` to use `pr/yarn.lock` and `base/yarn.lock`
- Changed `pnpm install --frozen-lockfile` → `yarn install --frozen-lockfile`
- Changed `pnpm exec rollup -c` → `yarn rollup -c`
- Changed `pnpm --filter <pkg> build` → `yarn workspace <pkg> build`