### PR TITLE
Replace post-publish demo sync with manual `pnpm sync-demos`

### DIFF
--- a/package-management-guide.md
+++ b/package-management-guide.md
@@ -207,7 +207,7 @@ Both [demo/vite.config.ts](demo/vite.config.ts) and [custom-component-library/vi
 
 The `local` mode is what you'll use 90% of the time during dev — edits in core/themes/components are picked up by vite's hot-reload without rebuilding.
 
-The `npm` mode is for **validating against the published artefact**. After publishing, install the latest versions in demo and CCL (`./scripts/installLatestPackage.mjs` does this automatically post-publish) and run `yarn start` to see exactly what a consumer would see.
+The `npm` mode is for **validating against the published artefact**. After publishing, run `pnpm sync-demos` from the repo root to bump demo and CCL to the just-published versions, then `yarn start` to see exactly what a consumer would see.
 
 ## Versioning with Changesets
 
@@ -303,6 +303,10 @@ pnpm changeset publish
 
 # 6. Push commit + tags
 git push --follow-tags
+
+# 7. Bump demo + CCL to the just-published versions
+#    (polls npm until each new version is visible, then `yarn add` in each consumer)
+pnpm sync-demos
 ```
 
 `pnpm changeset publish` walks each workspace package, compares its local version against npm, and runs `pnpm publish` for anything that's ahead. The `publishConfig.access: public` in each scoped package's `package.json` ensures the `@json-edit-react/...` packages publish as public (npm scopes default to private).
@@ -484,7 +488,7 @@ Then re-run `pnpm install`. The symlink lands at `packages/<name>/node_modules/j
 
 Right — the themes and components packages haven't been published to npm yet. The `npm` mode for those packages only works after the first publish. Use `local` mode (`VITE_JRE_SOURCE=local`) in the meantime; it routes through vite aliases to the in-repo source.
 
-After the first publish, run `./scripts/installLatestPackage.mjs` (or update demo/CCL `package.json` deps manually) to install the published versions.
+After the first publish, run `pnpm sync-demos` (or update demo/CCL `package.json` deps manually) to install the published versions.
 
 ### How do I un-publish a bad release?
 

--- a/package.json
+++ b/package.json
@@ -35,10 +35,11 @@
     "lint": "eslint",
     "prepareReadme": "python3 scripts/build_npm_readme.py",
     "prepublishOnly": "pnpm build && pnpm prepareReadme && python3 scripts/use_npm_readme.py prepare",
-    "postpublish": "python3 scripts/use_npm_readme.py restore && node scripts/installLatestPackage.mjs pause &",
+    "postpublish": "python3 scripts/use_npm_readme.py restore",
     "compile": "tsc --noEmit && ts-prune",
     "release": "pnpm publish",
-    "release-demo": "cd demo && yarn deploy"
+    "release-demo": "cd demo && yarn deploy",
+    "sync-demos": "node scripts/installLatestPackage.mjs"
   },
   "peerDependencies": {
     "react": ">=16.0.0"

--- a/scripts/installLatestPackage.mjs
+++ b/scripts/installLatestPackage.mjs
@@ -1,60 +1,92 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process'
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const foldersToInstall = ['demo', 'custom-component-library']
-const packageName = 'json-edit-react'
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
-/**
- * Installs the most recent version of a package (stable or beta)
- * @param {string} packageName - The name of the package to check
- */
-async function installLatestPackage() {
-  console.log('Installing most recent version of the published package in apps...')
+const PACKAGES = [
+  { name: 'json-edit-react', pkgJsonPath: 'package.json' },
+  { name: '@json-edit-react/themes', pkgJsonPath: 'packages/themes/package.json' },
+  { name: '@json-edit-react/components', pkgJsonPath: 'packages/components/package.json' },
+]
+
+const CONSUMERS = ['demo', 'custom-component-library']
+
+const POLL_INTERVAL_MS = 5_000
+const POLL_MAX_ATTEMPTS = 24 // 24 * 5s = 2 min
+
+const readJson = (relPath) => JSON.parse(readFileSync(join(ROOT, relPath), 'utf8'))
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+const getConsumerDep = (consumerPkg, name) =>
+  consumerPkg.dependencies?.[name] ?? consumerPkg.devDependencies?.[name] ?? null
+
+const npmHasVersion = (name, version) => {
   try {
-    // Get all package info in a single call
-    const packageData = JSON.parse(execSync(`npm view ${packageName} --json`).toString())
-
-    // Get stable version from dist-tags (always exists)
-    const stableVersion = packageData['dist-tags'].latest
-    const stableDate = new Date(packageData.time[stableVersion])
-
-    console.log(`Latest stable: ${stableVersion} (${stableDate.toISOString()})`)
-
-    // Check if beta tag exists
-    if (!packageData['dist-tags'].beta) {
-      console.log('No beta version available. Installing stable version')
-      installPackage(packageName, stableVersion, foldersToInstall)
-      return
-    }
-
-    // Get beta version and timestamp
-    const betaVersion = packageData['dist-tags'].beta
-    const betaDate = new Date(packageData.time[betaVersion])
-
-    console.log(`Latest beta: ${betaVersion} (${betaDate.toISOString()})`)
-
-    // Compare dates and install the most recent version
-    if (betaDate > stableDate) {
-      installPackage(packageName, betaVersion, foldersToInstall)
-    } else {
-      installPackage(packageName, stableVersion, foldersToInstall)
-    }
-  } catch (error) {
-    console.error('Error checking or installing package:', error.message)
+    execSync(`npm view ${name}@${version} version`, {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return true
+  } catch {
+    return false
   }
 }
 
-const installPackage = (packageName, version, installFolders) => {
-  for (const folder of installFolders) {
-    console.log(`Installing version ${version} in ${folder}`)
-    execSync(`cd ${folder} && yarn add ${packageName}@${version}`, { stdio: 'inherit' })
+const waitForPublish = async (name, version) => {
+  for (let attempt = 1; attempt <= POLL_MAX_ATTEMPTS; attempt++) {
+    if (npmHasVersion(name, version)) return true
+    console.log(`    waiting for ${name}@${version} on npm (${attempt}/${POLL_MAX_ATTEMPTS})`)
+    if (attempt < POLL_MAX_ATTEMPTS) await sleep(POLL_INTERVAL_MS)
+  }
+  return false
+}
+
+const syncDemos = async () => {
+  console.log('Syncing demo apps to published library versions\n')
+
+  const targets = PACKAGES.map((p) => ({
+    name: p.name,
+    version: readJson(p.pkgJsonPath).version,
+  }))
+
+  for (const consumer of CONSUMERS) {
+    console.log(`[${consumer}]`)
+    const consumerPkg = readJson(`${consumer}/package.json`)
+
+    for (const { name, version } of targets) {
+      const currentDep = getConsumerDep(consumerPkg, name)
+      if (!currentDep) {
+        console.log(`  - ${name}: not a dependency, skipping`)
+        continue
+      }
+      if (currentDep === version) {
+        console.log(`  - ${name}@${version}: already current`)
+        continue
+      }
+      console.log(`  - ${name}: ${currentDep} -> ${version}`)
+
+      const available = await waitForPublish(name, version)
+      if (!available) {
+        console.error(
+          `    ! ${name}@${version} not on npm after ${POLL_MAX_ATTEMPTS} attempts, skipping`
+        )
+        continue
+      }
+
+      execSync(`yarn add ${name}@${version}`, {
+        cwd: join(ROOT, consumer),
+        stdio: 'inherit',
+      })
+    }
+    console.log()
   }
 }
 
-const pause = process.argv[2] === 'pause'
-
-if (pause) {
-  console.log('Pausing installation to wait for newly published package...')
-  setTimeout(() => installLatestPackage(), 10_000)
-} else installLatestPackage(packageName)
+syncDemos().catch((err) => {
+  console.error('sync-demos failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- The old `postpublish` flow background-launched `scripts/installLatestPackage.mjs` after a 10s sleep and only bumped `json-edit-react` in demo + CCL. With Changesets that's broken in two ways: a themes-only or components-only release wouldn't trigger core's `postpublish` at all, and even when it does fire it misses the two sub-packages.
- Rewrites `scripts/installLatestPackage.mjs` to read target versions from each package's local `package.json`, only touch deps the consumer actually declares, and poll npm (5s × 24 = 2 min) for the exact version before running `yarn add`. Skips silently when a package isn't a dependency, so the same script keeps working before and after the `@json-edit-react/*` packages are first published.
- Exposes it as `pnpm sync-demos` and removes the install step from `postpublish` (README restore still runs).
- Updates `package-management-guide.md`: adds `pnpm sync-demos` as step 7 of the release flow and fixes two stale references that claimed the install ran automatically.

## Test plan

- [ ] Drop `json-edit-react` in `demo/package.json` and `custom-component-library/package.json` to `1.30.0` (one minor below the currently-published `1.30.1`).
- [ ] Run `pnpm sync-demos` from the repo root.
- [ ] Expect: for each consumer, log shows `json-edit-react: 1.30.0 -> 1.30.1`, npm probe succeeds immediately, `yarn add` runs, and the two `@json-edit-react/*` sub-packages are reported as `not a dependency, skipping`.
- [ ] Confirm `demo/package.json`, `custom-component-library/package.json`, and both `yarn.lock` files end up at `1.30.1`.
- [ ] End-to-end verification (script triggered against just-published versions) has to wait for the real v2 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)