### PR TITLE
V2 §2: Path identity — drop dot-joined strings

### DIFF
--- a/.changeset/path-identity-arrays.md
+++ b/.changeset/path-identity-arrays.md
@@ -1,0 +1,12 @@
+---
+'json-edit-react': major
+---
+
+Path identity is now `CollectionKey[]` everywhere instead of a dot-joined string.
+
+- The internal editing-state, drag-source, and `areChildrenBeingEdited` checks all compare arrays directly, fixing two classes of bug at once:
+  - Keys containing `.` no longer collide with deeper paths (e.g. `['foo.bar', 'baz']` is now distinguishable from `['foo', 'bar', 'baz']`).
+  - The "is a descendant" check is a proper array prefix, not a string substring — so editing `foobar` no longer claims `foo`'s children are editing, and dragging `foo` no longer hides the drop highlight on `foobar`.
+- `toPathString` is still exported, but its encoding changes to `/`-joined `encodeURIComponent` (e.g. `['data', 0, 'name']` → `'data/0/name'`). The result is now provably injective. The optional second `key?: 'key_'` argument is removed — the new identity model encodes value-vs-key mode as a field, not a string prefix. **If you only use `toPathString`'s output as an HTML `name`/`id`, no code change is needed.**
+
+See the [migration guide](../migration-guide.md#5-topathstring-encoding-changed) for details.

--- a/README.md
+++ b/README.md
@@ -1297,7 +1297,7 @@ A few helper functions, components and types that might be useful in your own im
 - `extract`: function to extract a deeply nested object value from a string path. Originally published at [object-property-extractor](https://github.com/CarlosNZ/object-property-extractor)
 - `assign`: function to set a deep object value from a string path. Originally published at [object-property-assigner](https://github.com/CarlosNZ/object-property-assigner)
 - `isCollection`: simple utility that returns `true` if input is a "Collection" (i.e. an Object or Array)
-- `toPathString`: transforms a path array to a string representation, e.g.  `["data", 0, "property1", "name"] => "data.0.property1.name"`
+- `toPathString`: transforms a path array to a string representation suitable for HTML `name`/`id` attributes, e.g.  `["data", 0, "property1", "name"] => "data/0/property1/name"`. Keys are URL-encoded so the result is unambiguous even when keys contain `/` or other special characters.
 - `defaultTheme`: the "default" theme baseline used when no `theme` prop is supplied. (Additional themes ship in [`@json-edit-react/themes`](#themes--styles).)
 - `standardDataTypes`: array containing all standard data types: `[ 'string','number', 'boolean', 'null', 'object', 'array' ]`
 

--- a/V2-roadmap.md
+++ b/V2-roadmap.md
@@ -11,7 +11,7 @@ The aim of v2.0 is **clean house, not ship features**. Feature additions belong 
 Numbering matches the section numbers below. Items joined with `+` are interlocked and best tackled together.
 
 - §1 Generic `JsonEditor<T>` ✅ (foundational type model)
-- §2 Path identity (foundational identity model) — [#246](https://github.com/CarlosNZ/json-edit-react/issues/246)
+- §2 Path identity ✅ (foundational identity model) — [#246](https://github.com/CarlosNZ/json-edit-react/issues/246)
 - §3 Tests (regression net for everything that follows) — [#61](https://github.com/CarlosNZ/json-edit-react/issues/61)
 - §4 `TreeStateProvider` refactor (depends on §2; unlocks the perf work in §16) — [#247](https://github.com/CarlosNZ/json-edit-react/issues/247)
 - §5 Drop controlled/uncontrolled dual mode (state simplification) — [#248](https://github.com/CarlosNZ/json-edit-react/issues/248)
@@ -42,11 +42,11 @@ interface JsonEditorProps<T = JsonData> {
 
 Landed in [#240](https://github.com/CarlosNZ/json-edit-react/pull/240). `T` flows to `data`, `setData`, the root-data slots of `UpdateFunction` / `OnChangeFunction` / `OnErrorFunction`, and `NodeData.fullData` (which propagates into every `FilterFunction` variant). Default `T = JsonData` keeps existing untyped code source-compatible. Per-node `value` / `parentData` stay wide — they're arbitrary-depth slices no static type can describe. The recursive internal `Editor` stays pinned to `JsonEditorProps<JsonData>`; the outer wrapper casts at the boundary. `CustomNodeDefinition` intentionally didn't gain a `T` generic — would have made mixed-shape arrays unworkable. See [migration-guide.md](migration-guide.md) for consumer guidance.
 
-## 2. Path identity — drop dot-joined strings
+## 2. Path identity — drop dot-joined strings — ✅ done
 
-[`toPathString`](src/helpers.ts) joins keys with `.` and patches empty strings with `\0`. Keys containing dots produce ambiguous paths. Worse, `areChildrenBeingEdited` in [TreeStateProvider.tsx](src/contexts/TreeStateProvider.tsx) does `pathString.includes(...)` — a **substring** match, so `"foo"` claims `"foobar"`'s children are being edited.
+[`toPathString`](src/helpers.ts) joined keys with `.` and patched empty strings with `\0`. Keys containing dots produced ambiguous paths, and `areChildrenBeingEdited` in [TreeStateProvider.tsx](src/contexts/TreeStateProvider.tsx) used `pathString.includes(...)` — a **substring** match — so `"foo"` claimed `"foobar"`'s children were being edited.
 
-Use `CollectionKey[]` as node identity everywhere; only stringify for React keys (and use a safe encoding there).
+Landed in [#260](https://github.com/CarlosNZ/json-edit-react/pull/260). `CollectionKey[]` is the canonical node identity throughout — editing state is `{ path, mode }`, drag source carries `path` only, and `areChildrenBeingEdited` plus the drag-onto-self guard use new array predicates (`pathsEqual`, `isDescendantOf`). `toPathString` survives as a public utility but its encoding switched to `/` + `encodeURIComponent` (injective, with a `'\0'` sentinel for the single-empty-key edge case); the `'key_'` second arg is removed since mode is now a field. Also fixed a latent same-family bug in `handleDrop` where `sourceBase`/`thisBase` were joined with mismatched separators. See [migration-guide.md](migration-guide.md#5-topathstring-encoding-changed).
 
 ## 3. Tests
 

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -170,6 +170,27 @@ It joins the existing rendering primitives — `StringDisplay`, `StringEdit`, `t
 
 ---
 
+## 5. `toPathString` encoding changed
+
+`toPathString` now joins keys with `/` (URL-encoded) instead of `.`, so the encoding is unambiguous even when keys themselves contain `.` or `/`.
+
+```js
+// Before (v1)
+toPathString(['data', 0, 'name'])          // 'data.0.name'
+toPathString(['foo.bar', 'baz'])           // 'foo.bar.baz' — collides with ['foo','bar','baz']
+
+// After (v2)
+toPathString(['data', 0, 'name'])          // 'data/0/name'
+toPathString(['foo.bar', 'baz'])           // 'foo.bar/baz' — now distinguishable
+toPathString(['has/slash', 'x'])           // 'has%2Fslash/x'
+```
+
+The second `key?: 'key_'` parameter has been removed — it was an internal encoding trick that's no longer needed.
+
+If you used `toPathString`'s output as an HTML `name` or `id` attribute (e.g. inside a custom component), nothing about how you use it changes; the string just looks different. If you parsed the returned string back into a path, you'll need to switch to `decodeURIComponent` per segment after splitting on `/`.
+
+---
+
 ## Need help?
 
 If you hit something this guide doesn't cover, please [open an issue](https://github.com/CarlosNZ/json-edit-react/issues) — happy to help triage and add to this doc.

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -27,7 +27,6 @@ export const CollectionNode: React.FC<CollectionNodeProps> = (props) => {
     collapseState,
     setCollapseState,
     getMatchingCollapseState,
-    currentlyEditingElement,
     setCurrentlyEditingElement,
     areChildrenBeingEdited,
     previousValue,
@@ -173,7 +172,7 @@ export const CollectionNode: React.FC<CollectionNodeProps> = (props) => {
     showCollectionWrapper = true,
   } = customNodeData
 
-  const childrenEditing = areChildrenBeingEdited(pathString)
+  const childrenEditing = areChildrenBeingEdited(path)
 
   // For when children are accessed via Tab
   if (childrenEditing && collapsed) animateCollapse(false)
@@ -214,7 +213,7 @@ export const CollectionNode: React.FC<CollectionNodeProps> = (props) => {
       setCollapseState({ collapsed: !collapsed, path, includeChildren: true })
       return
     }
-    if (!(currentlyEditingElement && currentlyEditingElement.includes(pathString))) {
+    if (!areChildrenBeingEdited(path)) {
       hasBeenOpened.current = true
       setCollapseState(null)
       if (onCollapse) onCollapse({ path, collapsed: !collapsed, includeChildren: false })

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -282,7 +282,7 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
       cancel: handleCancel,
       tabForward: () => {
         setTabDirection('next')
-        setPreviouslyEditedElement(pathString)
+        setPreviouslyEditedElement(path)
         const next = getNextOrPrevious(nodeData.fullData, path, 'next', sort)
         if (next) {
           handleEdit()
@@ -291,7 +291,7 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
       },
       tabBack: () => {
         setTabDirection('prev')
-        setPreviouslyEditedElement(pathString)
+        setPreviouslyEditedElement(path)
         const prev = getNextOrPrevious(nodeData.fullData, path, 'prev', sort)
         if (prev) {
           handleEdit()

--- a/src/contexts/TreeStateProvider.tsx
+++ b/src/contexts/TreeStateProvider.tsx
@@ -15,26 +15,26 @@ import {
   type OnEditEventFunction,
   type OnCollapseFunction,
   type CollapseState,
+  type EditingState,
 } from '../types'
-import { toPathString } from '../helpers'
+import { editingStatesEqual, isDescendantOf } from '../helpers'
 
 interface DragSource {
   path: CollectionKey[] | null
-  pathString: string | null
 }
 
 interface TreeStateContext {
   collapseState: CollapseState | CollapseState[] | null
   setCollapseState: (collapseState: CollapseState | CollapseState[] | null) => void
   getMatchingCollapseState: (path: CollectionKey[]) => CollapseState | null
-  currentlyEditingElement: string | null
+  currentlyEditingElement: EditingState | null
   setCurrentlyEditingElement: (
-    path: CollectionKey[] | string | null,
+    path: CollectionKey[] | null,
     cancelOpOrKey?: (() => void) | 'key'
   ) => void
-  previouslyEditedElement: string | null
-  setPreviouslyEditedElement: (path: string) => void
-  areChildrenBeingEdited: (pathString: string) => boolean
+  previouslyEditedElement: CollectionKey[] | null
+  setPreviouslyEditedElement: (path: CollectionKey[]) => void
+  areChildrenBeingEdited: (path: CollectionKey[]) => boolean
   dragSource: DragSource
   setDragSource: (newState: DragSource) => void
   tabDirection: TabDirection
@@ -53,16 +53,13 @@ interface TreeStateProps {
 
 export const TreeStateProvider = ({ children, onEditEvent, onCollapse }: TreeStateProps) => {
   const [collapseState, setCollapseState] = useState<CollapseState | CollapseState[] | null>(null)
-  const [currentlyEditingElement, setCurrentlyEditingElement] = useState<string | null>(null)
+  const [currentlyEditingElement, setCurrentlyEditingElement] = useState<EditingState | null>(null)
 
   // This value holds the "previous" value when user changes type. Because
   // changing data type causes a proper data update, cancelling afterwards
   // doesn't revert to the previous type. This value allows us to do that.
   const [previousValue, setPreviousValue] = useState<JsonData | null>(null)
-  const [dragSource, setDragSource] = useState<DragSource>({
-    path: null,
-    pathString: null,
-  })
+  const [dragSource, setDragSource] = useState<DragSource>({ path: null })
   const cancelOp = useRef<(() => void) | null>(null)
 
   // tabDirection and previouslyEdited are used in Tab navigation. Each node can
@@ -72,26 +69,29 @@ export const TreeStateProvider = ({ children, onEditEvent, onCollapse }: TreeSta
   // shouldn't be, it immediately goes to the next (and the next, etc...). These
   // two values hold some state which is useful in this slightly messy process.
   const tabDirection = useRef<TabDirection>('next')
-  const previouslyEdited = useRef<string | null>(null)
+  const previouslyEdited = useRef<CollectionKey[] | null>(null)
 
   const updateCurrentlyEditingElement = (
-    path: CollectionKey[] | string | null,
+    path: CollectionKey[] | null,
     newCancelOrKey?: (() => void) | 'key'
   ) => {
-    const pathString =
-      typeof path === 'string' || path === null
-        ? path
-        : toPathString(path, newCancelOrKey === 'key' ? 'key_' : undefined)
+    const nextState: EditingState | null =
+      path === null ? null : { path, mode: newCancelOrKey === 'key' ? 'key' : 'value' }
 
     // The "Cancel" function allows the UI to reset the element that was
     // previously being edited if the user clicks another "Edit" button
     // elsewhere
-    if (currentlyEditingElement !== null && pathString !== null && cancelOp.current !== null) {
+    if (currentlyEditingElement !== null && nextState !== null && cancelOp.current !== null) {
       cancelOp.current()
     }
-    setCurrentlyEditingElement(pathString)
-    if (onEditEvent && (Array.isArray(path) || path === null))
-      onEditEvent(path, newCancelOrKey === 'key')
+
+    // Skip setState when the editing state is equivalent — avoids redundant
+    // re-renders when callers re-issue the same edit target. React's `===`
+    // bailout doesn't help here because nextState is a fresh object each call.
+    if (!editingStatesEqual(nextState, currentlyEditingElement))
+      setCurrentlyEditingElement(nextState)
+
+    if (onEditEvent) onEditEvent(path, newCancelOrKey === 'key')
     cancelOp.current = typeof newCancelOrKey === 'function' ? newCancelOrKey : null
   }
 
@@ -109,8 +109,8 @@ export const TreeStateProvider = ({ children, onEditEvent, onCollapse }: TreeSta
     return doesCollapseStateMatchPath(path, collapseState) ? collapseState : null
   }
 
-  const areChildrenBeingEdited = (pathString: string) =>
-    currentlyEditingElement !== null && currentlyEditingElement.includes(pathString)
+  const areChildrenBeingEdited = (path: CollectionKey[]) =>
+    currentlyEditingElement !== null && isDescendantOf(currentlyEditingElement.path, path)
 
   return (
     <TreeStateProviderContext.Provider
@@ -134,7 +134,7 @@ export const TreeStateProvider = ({ children, onEditEvent, onCollapse }: TreeSta
         setCurrentlyEditingElement: updateCurrentlyEditingElement,
         areChildrenBeingEdited,
         previouslyEditedElement: previouslyEdited.current,
-        setPreviouslyEditedElement: (path: string) => {
+        setPreviouslyEditedElement: (path: CollectionKey[]) => {
           previouslyEdited.current = path
         },
         tabDirection: tabDirection.current,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -14,6 +14,7 @@ import {
   type EnumDefinition,
   type CollectionData,
   type ValueData,
+  type EditingState,
 } from './types'
 
 export const isCollection = (value: unknown): value is Record<string, unknown> | unknown[] =>
@@ -126,15 +127,32 @@ export const matchNodeKey: SearchFilterFunction = ({ key, path }, searchText = '
 }
 
 /**
- * Converts a part expressed as an array of properties to a single string
+ * Converts a path expressed as an array of CollectionKeys to a string suitable
+ * for HTML `name`/`id` attributes. The encoding is injective: keys are
+ * URL-encoded (so any literal `/` becomes `%2F`) and joined with `/`. Because
+ * `encodeURIComponent` never emits `/`, the separator can only appear between
+ * keys, never inside one — so distinct paths always produce distinct strings.
  */
-export const toPathString = (path: Array<string | number>, key?: 'key_') =>
-  (key ?? '') +
-  path
-    // An empty string in a part will "disappear", so replace it with a
-    // non-printable char
-    .map((part) => (part === '' ? String.fromCharCode(0) : part))
-    .join('.')
+export const toPathString = (path: CollectionKey[]) =>
+  path.map((part) => encodeURIComponent(String(part))).join('/')
+
+export const pathsEqual = (a: CollectionKey[], b: CollectionKey[]): boolean =>
+  a.length === b.length && a.every((k, i) => k === b[i])
+
+// Reflexive: a node is considered a (trivial) descendant of itself. Both
+// callers (areChildrenBeingEdited, drag-onto-self guard) want this behaviour.
+export const isDescendantOf = (
+  node: CollectionKey[],
+  ancestor: CollectionKey[]
+): boolean => node.length >= ancestor.length && ancestor.every((k, i) => k === node[i])
+
+export const editingStatesEqual = (
+  a: EditingState | null,
+  b: EditingState | null
+): boolean => {
+  if (a === null || b === null) return a === b
+  return a.mode === b.mode && pathsEqual(a.path, b.path)
+}
 
 /**
  * KEYBOARD INTERACTION

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -132,9 +132,16 @@ export const matchNodeKey: SearchFilterFunction = ({ key, path }, searchText = '
  * URL-encoded (so any literal `/` becomes `%2F`) and joined with `/`. Because
  * `encodeURIComponent` never emits `/`, the separator can only appear between
  * keys, never inside one — so distinct paths always produce distinct strings.
+ *
+ * One edge case needs a sentinel: a single empty-string key `['']` would
+ * otherwise produce `''` and collide with the root path `[]`. We map it to
+ * `'\0'` instead — safe because `encodeURIComponent` never emits a literal
+ * null char (it produces `'%00'` for the null byte).
  */
-export const toPathString = (path: CollectionKey[]) =>
-  path.map((part) => encodeURIComponent(String(part))).join('/')
+export const toPathString = (path: CollectionKey[]) => {
+  if (path.length === 1 && path[0] === '') return '\0'
+  return path.map((part) => encodeURIComponent(String(part))).join('/')
+}
 
 export const pathsEqual = (a: CollectionKey[], b: CollectionKey[]): boolean =>
   a.length === b.length && a.every((k, i) => k === b[i])

--- a/src/hooks/useCommon.ts
+++ b/src/hooks/useCommon.ts
@@ -13,7 +13,7 @@ import {
   type ValueNodeProps,
   type JsonData,
 } from '../types'
-import { toPathString } from '../helpers'
+import { pathsEqual, toPathString } from '../helpers'
 
 interface CommonProps {
   props: CollectionNodeProps | ValueNodeProps
@@ -97,8 +97,11 @@ export const useCommon = ({ props, collapsed }: CommonProps) => {
   }
 
   // Common DERIVED VALUES (this makes the JSX logic less messy)
-  const isEditing = currentlyEditingElement === pathString
-  const isEditingKey = currentlyEditingElement === `key_${pathString}`
+  const isEditing =
+    currentlyEditingElement?.mode === 'value' &&
+    pathsEqual(currentlyEditingElement.path, path)
+  const isEditingKey =
+    currentlyEditingElement?.mode === 'key' && pathsEqual(currentlyEditingElement.path, path)
   const isArray = typeof path.slice(-1)[0] === 'number'
   const canEditKey = parentData !== null && canEdit && canAdd && canDelete && !isArray
 

--- a/src/hooks/useDragNDrop.tsx
+++ b/src/hooks/useDragNDrop.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import { useTreeState, useTheme } from '../contexts'
-import { toPathString } from '../helpers'
+import { isDescendantOf, pathsEqual } from '../helpers'
 import {
   type NodeData,
   type CollectionKey,
@@ -34,23 +34,21 @@ export const useDragNDrop = ({
   const { dragSource, setDragSource } = useTreeState()
   const [isDragTarget, setIsDragTarget] = useState<Position | false>(false)
 
-  const pathString = toPathString(path)
-
   // Props added to items being dragged
   const dragSourceProps = useMemo(() => {
     if (!canDrag) return {}
     return {
       onDragStart: (e: React.DragEvent) => {
         e.stopPropagation()
-        setDragSource({ path, pathString })
+        setDragSource({ path })
       },
       onDragEnd: (e: React.DragEvent) => {
         e.stopPropagation()
-        setDragSource({ path: null, pathString: null })
+        setDragSource({ path: null })
       },
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [canDrag, pathString])
+  }, [canDrag, path])
 
   // Props for the items being dropped onto
   const getDropTargetProps = useMemo(
@@ -64,12 +62,14 @@ export const useDragNDrop = ({
         onDrop: (e: React.DragEvent) => {
           e.stopPropagation()
           handleDrop(position)
-          setDragSource({ path: null, pathString: null })
+          setDragSource({ path: null })
           setIsDragTarget(false)
         },
         onDragEnter: (e: React.DragEvent) => {
           e.stopPropagation()
-          if (!pathString.startsWith(dragSource.pathString ?? '')) {
+          // Block highlighting when dragging onto self or any descendant of the
+          // drag source (reflexive descendant check)
+          if (dragSource.path === null || !isDescendantOf(path, dragSource.path)) {
             setIsDragTarget(position)
           }
         },
@@ -80,7 +80,7 @@ export const useDragNDrop = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [dragSource, canDragOnto, pathString]
+    [dragSource, canDragOnto, path]
   )
 
   // A dummy component to allow us to detect when dragging onto the *bottom*
@@ -88,7 +88,7 @@ export const useDragNDrop = ({
   // locked to the bottom.
   const BottomDropTarget = useMemo(
     () =>
-      canDragOnto && dragSource.pathString !== null ? (
+      canDragOnto && dragSource.path !== null ? (
         <div
           className="jer-drop-target-bottom"
           style={{
@@ -118,9 +118,10 @@ export const useDragNDrop = ({
   }
 
   const handleDrop = (position: Position) => {
-    const sourceKey = dragSource.path?.slice(-1)[0]
-    const sourceBase = dragSource.path?.slice(0, -1).join('.')
-    const thisBase = path.slice(0, -1).join('')
+    if (dragSource.path === null) return
+    const sourceKey = dragSource.path.slice(-1)[0]
+    const sourceParent = dragSource.path.slice(0, -1)
+    const thisParent = path.slice(0, -1)
     const { parentData } = nodeData
     if (
       typeof sourceKey === 'string' &&
@@ -128,7 +129,7 @@ export const useDragNDrop = ({
       !Array.isArray(parentData) &&
       Object.keys(parentData).includes(sourceKey) &&
       sourceKey in parentData &&
-      sourceBase !== thisBase
+      !pathsEqual(sourceParent, thisParent)
     ) {
       onError({ code: 'KEY_EXISTS', message: translate('ERROR_KEY_EXISTS', nodeData) }, sourceKey)
     } else {

--- a/src/hooks/useTriggers.ts
+++ b/src/hooks/useTriggers.ts
@@ -6,7 +6,7 @@
 import { useEffect } from 'react'
 import { useTreeState } from '../contexts'
 import { type CollectionKey, type CollapseState } from '../types'
-import { toPathString } from '../helpers'
+import { pathsEqual } from '../helpers'
 
 export interface EditState {
   path?: CollectionKey[]
@@ -37,7 +37,9 @@ export const useTriggers = (
 
     // EDIT
 
-    const doesPathMatch = edit?.path ? toPathString(edit.path) === currentlyEditingElement : true
+    const doesPathMatch = edit?.path
+      ? currentlyEditingElement !== null && pathsEqual(edit.path, currentlyEditingElement.path)
+      : true
 
     switch (edit?.action) {
       case 'accept': {

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,11 @@ export type ErrorString = string
 
 export type TabDirection = 'next' | 'prev'
 
+export interface EditingState {
+  path: CollectionKey[]
+  mode: 'value' | 'key'
+}
+
 export interface IconReplacements {
   add?: JSX.Element
   edit?: JSX.Element

--- a/test/pathHelpers.test.ts
+++ b/test/pathHelpers.test.ts
@@ -1,0 +1,100 @@
+import { isDescendantOf, pathsEqual, toPathString } from '../src/helpers'
+
+describe('pathsEqual', () => {
+  test('equal arrays', () => {
+    expect(pathsEqual([], [])).toBe(true)
+    expect(pathsEqual(['a'], ['a'])).toBe(true)
+    expect(pathsEqual(['a', 'b', 0], ['a', 'b', 0])).toBe(true)
+  })
+
+  test('differing length', () => {
+    expect(pathsEqual(['a'], ['a', 'b'])).toBe(false)
+    expect(pathsEqual(['a', 'b'], ['a'])).toBe(false)
+    expect(pathsEqual([], ['a'])).toBe(false)
+  })
+
+  test('differing content', () => {
+    expect(pathsEqual(['a'], ['b'])).toBe(false)
+    expect(pathsEqual(['a', 'b'], ['a', 'c'])).toBe(false)
+    expect(pathsEqual(['a', 'b', 'c'], ['a', 'b', 'd'])).toBe(false)
+  })
+
+  test('mixed string/number keys — strict equality', () => {
+    // Numeric array index 0 is not equal to the string "0"
+    expect(pathsEqual(['a', 0], ['a', '0'])).toBe(false)
+    expect(pathsEqual(['a', 0], ['a', 0])).toBe(true)
+  })
+})
+
+describe('isDescendantOf', () => {
+  test('reflexive: a path is a descendant of itself', () => {
+    expect(isDescendantOf([], [])).toBe(true)
+    expect(isDescendantOf(['a'], ['a'])).toBe(true)
+    expect(isDescendantOf(['a', 'b', 0], ['a', 'b', 0])).toBe(true)
+  })
+
+  test('strict descendants', () => {
+    expect(isDescendantOf(['a', 'b'], ['a'])).toBe(true)
+    expect(isDescendantOf(['a', 'b', 'c'], ['a'])).toBe(true)
+    expect(isDescendantOf(['a', 0, 'name'], ['a', 0])).toBe(true)
+    // The empty path is the root: everything descends from it
+    expect(isDescendantOf(['a'], [])).toBe(true)
+    expect(isDescendantOf(['a', 'b'], [])).toBe(true)
+  })
+
+  test('ancestors are not descendants', () => {
+    expect(isDescendantOf(['a'], ['a', 'b'])).toBe(false)
+    expect(isDescendantOf([], ['a'])).toBe(false)
+  })
+
+  test('siblings and unrelated paths', () => {
+    expect(isDescendantOf(['a'], ['b'])).toBe(false)
+    expect(isDescendantOf(['a', 'b'], ['a', 'c'])).toBe(false)
+    expect(isDescendantOf(['x', 'y'], ['a', 'b'])).toBe(false)
+  })
+
+  test('substring lookalikes do NOT match', () => {
+    // A string-substring check on a path stringification would match these
+    // pairs incorrectly (e.g. `"foobar".includes("foo")` is true). Array
+    // identity rejects them.
+    expect(isDescendantOf(['foobar'], ['foo'])).toBe(false)
+    expect(isDescendantOf(['foobar', 'name'], ['foo'])).toBe(false)
+    expect(isDescendantOf(['foo'], ['foobar'])).toBe(false)
+  })
+})
+
+describe('toPathString', () => {
+  test('basic encoding', () => {
+    expect(toPathString([])).toBe('')
+    expect(toPathString(['a'])).toBe('a')
+    expect(toPathString(['data', 0, 'name'])).toBe('data/0/name')
+  })
+
+  test('dotted keys do not collide with deeper paths', () => {
+    expect(toPathString(['foo.bar', 'baz'])).not.toBe(toPathString(['foo', 'bar', 'baz']))
+    expect(toPathString(['foo.bar', 'baz'])).toBe('foo.bar/baz')
+    expect(toPathString(['foo', 'bar', 'baz'])).toBe('foo/bar/baz')
+  })
+
+  test('literal slashes in keys are encoded so they cannot be confused with separators', () => {
+    expect(toPathString(['a/b', 'c'])).toBe('a%2Fb/c')
+    expect(toPathString(['a/b', 'c'])).not.toBe(toPathString(['a', 'b', 'c']))
+  })
+
+  test('literal percent signs are escaped (so %2F-in-key differs from encoded /)', () => {
+    expect(toPathString(['%2F', 'x'])).toBe('%252F/x')
+    expect(toPathString(['%2F', 'x'])).not.toBe(toPathString(['/', 'x']))
+  })
+
+  test('empty-string keys produce visible separators', () => {
+    expect(toPathString([''])).toBe('')
+    expect(toPathString(['a', '', 'b'])).toBe('a//b')
+    // Empty key adjacent to populated keys is unambiguous
+    expect(toPathString(['a', '', 'b'])).not.toBe(toPathString(['a', 'b']))
+  })
+
+  test('numeric and unicode keys round-trip cleanly', () => {
+    expect(toPathString([0, 1, 2])).toBe('0/1/2')
+    expect(toPathString(['héllo', 'wörld'])).toBe('h%C3%A9llo/w%C3%B6rld')
+  })
+})

--- a/test/pathHelpers.test.ts
+++ b/test/pathHelpers.test.ts
@@ -86,11 +86,51 @@ describe('toPathString', () => {
     expect(toPathString(['%2F', 'x'])).not.toBe(toPathString(['/', 'x']))
   })
 
-  test('empty-string keys produce visible separators', () => {
-    expect(toPathString([''])).toBe('')
-    expect(toPathString(['a', '', 'b'])).toBe('a//b')
-    // Empty key adjacent to populated keys is unambiguous
-    expect(toPathString(['a', '', 'b'])).not.toBe(toPathString(['a', 'b']))
+  describe('empty-string keys', () => {
+    test('mid-path: surrounded by separators', () => {
+      expect(toPathString(['a', '', 'b'])).toBe('a//b')
+      expect(toPathString(['a', '', 'b'])).not.toBe(toPathString(['a', 'b']))
+    })
+
+    test('at the end: trailing separator distinguishes', () => {
+      expect(toPathString(['a', ''])).toBe('a/')
+      expect(toPathString(['a', ''])).not.toBe(toPathString(['a']))
+    })
+
+    test('at the start: leading separator distinguishes', () => {
+      expect(toPathString(['', 'one'])).toBe('/one')
+      expect(toPathString(['', 'one'])).not.toBe(toPathString(['one']))
+    })
+
+    test('multiple empties — separator count preserves length', () => {
+      expect(toPathString(['', ''])).toBe('/')
+      expect(toPathString(['', '', ''])).toBe('//')
+      expect(toPathString(['', ''])).not.toBe(toPathString(['']))
+      expect(toPathString(['', ''])).not.toBe(toPathString(['', '', '']))
+    })
+
+    test('single empty key uses a sentinel to distinguish from root path', () => {
+      // The one case the join-based encoding cannot disambiguate from `[]`
+      // without help. `encodeURIComponent` never emits a literal '\0' (it
+      // produces '%00' for the null char), so '\0' is safe as a sentinel.
+      expect(toPathString([''])).toBe('\0')
+      expect(toPathString([''])).not.toBe(toPathString([]))
+    })
+
+    test('every distinct path produces a distinct string (injectivity)', () => {
+      const paths: (string | number)[][] = [
+        [],
+        [''],
+        ['a'],
+        ['', 'one'],
+        ['a', ''],
+        ['', ''],
+        ['', '', ''],
+        ['a', '', 'b'],
+        ['\0'],
+      ]
+      expect(new Set(paths.map(toPathString)).size).toBe(paths.length)
+    })
   })
 
   test('numeric and unicode keys round-trip cleanly', () => {


### PR DESCRIPTION
Closes #246. Part of the [V2.0 roadmap](../blob/v2.0-dev/V2-roadmap.md), §2.

## Summary

- Internal node identity is now `CollectionKey[]` everywhere instead of a dot-joined string.
- `areChildrenBeingEdited`, the drag-onto-self guard, and the editing-state comparisons all use array predicates (`pathsEqual`, `isDescendantOf`) — no more string `.includes()` / `.startsWith()` substring checks.
- `toPathString` survives as a public utility but its encoding changes to `/` + `encodeURIComponent` (injective by construction). The `key?: 'key_'` second arg is removed — mode is now a field on the editing-state object, not a string prefix.

## Bugs fixed

This kills three related bugs that were all rooted in the same string-encoding shortcut. Paste this into the demo to see them on `v2.0-dev` (and watch them vanish here):

\`\`\`json
{
  \"foo\": { \"name\": \"A\" },
  \"foobar\": { \"name\": \"B\" },
  \"with.dot\": \"I collide with 'with > dot'\",
  \"with\": { \"dot\": \"I collide with 'with.dot'\" }
}
\`\`\`

1. **Dotted-key collision.** Editing the root \`\"with.dot\"\` value used to put _both_ it and the nested \`with > dot\` value into edit mode simultaneously — they serialised to the same path string.
2. **Substring match in \`areChildrenBeingEdited\`.** Editing \`foobar > name\` would force the unrelated \`foo\` collection to open (because \`\"foobar.name\".includes(\"foo\")\`).
3. **Substring match in drag-onto-self guard.** Dragging \`foo\` over \`foobar\` would hide the drop indicator (\`\"foobar\".startsWith(\"foo\")\`).

Also fixes a related latent bug in \`handleDrop\` ([useDragNDrop.tsx:122–123](../blob/v2.0-dev/src/hooks/useDragNDrop.tsx#L122)) where \`sourceBase\` was joined with \`.\` but \`thisBase\` was joined with \`''\` — so \`KEY_EXISTS\` fired spuriously on legitimate same-parent drags at depth ≥ 3.

## Implementation shape

- Editing state is now \`{ path: CollectionKey[]; mode: 'value' | 'key' } | null\`, bundled so transitions are atomic (the §4 reducer work in #247 can grow this into a discriminated union naturally).
- \`previouslyEditedElement\` stays path-only (tab nav only ever targets value-mode).
- \`dragSource\` drops the mirrored \`pathString\` field.
- New helpers in \`src/helpers.ts\`: \`pathsEqual\`, \`isDescendantOf\` (reflexive — a path is a trivial descendant of itself; both callers want that), \`editingStatesEqual\`.

## Bundle size impact

Essentially a wash — adding new symbol names slightly reduces gzip efficiency:

| | Raw | Gzipped |
|---|---|---|
| ESM | 53,421 → 53,418 (−3 bytes) | 18,054 → 18,072 (+18 bytes, +0.10%) |
| CJS | 54,589 → 54,587 (−2 bytes) | 18,104 → 18,115 (+11 bytes, +0.06%) |

## Test plan

- [x] New unit tests in \`test/pathHelpers.test.ts\` cover \`pathsEqual\`, \`isDescendantOf\` (including reflexive case + substring-lookalike regression), and \`toPathString\` (encoding injectivity, slashes, percents, empties, unicode).
- [x] \`pnpm lint && pnpm compile && pnpm test\` — all green (126 tests).
- [x] \`pnpm -r build\` — core + themes + components all build cleanly.
- [x] Demo verification: paste the JSON above, confirm all three bugs are gone.
- [x] Tab navigation through the tree (exercises \`previouslyEditedElement\`).
- [ ] External \`edit\` trigger fires correctly on the matching path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)