### PR TITLE
Extract collapse contracts into named hooks (#276)

### DIFF
--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -4,7 +4,6 @@ import { EditButtons, InputButtons } from './ButtonPanels'
 import { getCustomNode } from './CustomNode'
 import {
   type CollectionNodeProps,
-  type CollapseState,
   type NodeData,
   type CollectionData,
   type ValueData,
@@ -15,7 +14,13 @@ import { getModifier, getNextOrPrevious, insertCharInTextArea } from './utils/ke
 import { isCollection } from './utils/misc'
 import { AutogrowTextArea } from './AutogrowTextArea'
 import { KeyDisplay } from './KeyDisplay'
-import { useTheme, useEditing, useCollapse, doesCollapseStateMatchPath } from './contexts'
+import {
+  useTheme,
+  useEditing,
+  useCollapse,
+  useAppliedBroadcast,
+  useReferenceChanged,
+} from './contexts'
 import { useCollapseTransition, useCommon, useDragNDrop } from './hooks'
 
 export const CollectionNode: React.FC<CollectionNodeProps> = (props) => {
@@ -27,7 +32,7 @@ export const CollectionNode: React.FC<CollectionNodeProps> = (props) => {
     previousValue,
     setPreviousValue,
   } = useEditing()
-  const { commands, version, setCollapseState } = useCollapse()
+  const { setCollapseState } = useCollapse()
   const {
     mainContainerRef,
     data,
@@ -117,66 +122,22 @@ export const CollectionNode: React.FC<CollectionNodeProps> = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data])
 
-  const collapseFilterHasChangedRef = useRef(false)
+  // Contract #2: prop-change retires broadcast. See CollapseProvider top-of-file doc.
+  const collapseFilterChanged = useReferenceChanged(collapseFilter)
   useEffect(() => {
     const shouldBeCollapsed = collapseFilter(nodeData) && !isEditing
     hasBeenOpened.current = !shouldBeCollapsed
     animateCollapse(shouldBeCollapsed)
-    if (collapseFilterHasChangedRef.current) {
-      // The `collapse` prop changed — that's a fresher user intent than any
-      // pending broadcast. Retire the broadcast so descendants that mount
-      // from this expansion follow the new prop, not the stale Collapse-All.
-      // Skipped on first-mount (the cascade-through-frontier case relies on
-      // freshly-mounted nodes seeing the still-set broadcast).
-      setCollapseState(null)
-    } else {
-      collapseFilterHasChangedRef.current = true
-    }
+    if (collapseFilterChanged) setCollapseState(null)
     // Only re-fire when `collapseFilter` itself changes — `animateCollapse`
     // depends on this node's own collapsed state, so listing it would make
     // the effect fight every user-driven expand/collapse.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collapseFilter])
 
-  // React to collapse-broadcast commands targeting this node. The version
-  // counter guards against re-applying the same broadcast: each broadcast
-  // bumps `version`, so a newly-mounted descendant (with `lastSeenVersionRef`
-  // still 0) sees a version mismatch on its first render and applies the
-  // still-present command — that's what makes the cascade reach past the
-  // initial mount frontier. `commands` persists in provider state until the
-  // next broadcast overwrites it, so the cascade always completes regardless
-  // of tree size; late mounts inherit the most recent broadcast.
-  //
-  // Only `[version, commands]` in deps — `path` and `animateCollapse` are
-  // closed over and captured fresh on every fire (effects re-create their
-  // closure on each run). Including them would fire the effect on every
-  // local collapse toggle and every parent re-render that hands down a new
-  // data ref, which for large trees adds significant React scheduling
-  // overhead even though the version check would early-return.
-  const lastSeenVersionRef = useRef(0)
-  useEffect(() => {
-    if (version === lastSeenVersionRef.current) return
-    lastSeenVersionRef.current = version
-    if (!commands) return
-    // Multiple matching commands collapse to a single `animateCollapse`
-    // call — last-write-wins per node. Calling `animateCollapse` more than
-    // once in the same effect fire would not produce the expected sequence:
-    // it closes over `collapsed` from render time and React batches the
-    // `setCollapsed` inside it, so the second call sees stale `collapsed`
-    // and either bails on the equality check or sets the wrong value.
-    let lastMatching: CollapseState | undefined
-    for (const cmd of commands) {
-      if (doesCollapseStateMatchPath(path, cmd)) lastMatching = cmd
-    }
-    if (!lastMatching) return
-    // Only force-open the mount gate when expanding. A collapse broadcast
-    // must not flip `hasBeenOpened` true on a node that hasn't been opened
-    // — that would mount its descendants on the next render, undoing the
-    // "don't mount descendants of never-opened nodes" perf optimization.
-    if (!lastMatching.collapsed) hasBeenOpened.current = true
-    animateCollapse(lastMatching.collapsed)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [version, commands])
+  // Contract #1: apply broadcast commands targeting this node. See
+  // CollapseProvider top-of-file doc.
+  useAppliedBroadcast(path, hasBeenOpened, animateCollapse)
 
   // For JSON-editing TextArea
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
@@ -280,8 +241,7 @@ export const CollectionNode: React.FC<CollectionNodeProps> = (props) => {
   }
 
   const handleAdd = (key: string) => {
-    // Clear any pending broadcast so the freshly mounted child uses its
-    // default state instead of inheriting (e.g. a recent Collapse-All).
+    // Contract #3: user-action clears broadcast. See CollapseProvider top-of-file doc.
     setCollapseState(null)
     animateCollapse(false)
     const newValue = getDefaultNewValue(nodeData, key)

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -190,9 +190,7 @@ export const ValueNodeWrapper: React.FC<ValueNodeProps> = (props) => {
   if (!isVisible) return null
 
   const handleChangeDataType = (type: DataType) => {
-    // Clear any pending broadcast so a primitive-to-collection conversion
-    // mounts a fresh CollectionNode in its default state instead of
-    // inheriting (e.g. a recent Collapse-All).
+    // Contract #3: user-action clears broadcast. See CollapseProvider top-of-file doc.
     setCollapseState(null)
     // Snapshot the original value before any type-change `onEdit` fires, so
     // a subsequent cancel can revert. Gated on `previousValue === null` so a

--- a/src/contexts/CollapseProvider.tsx
+++ b/src/contexts/CollapseProvider.tsx
@@ -1,45 +1,77 @@
 /**
- * Collapse broadcasts for the tree. Used to trigger whole-tree (or
- * subtree-targeted) expand/collapse operations from outside any specific node.
+ * Collapse broadcasts for the tree. Drives whole-tree (or subtree-targeted)
+ * expand/collapse operations from outside any specific node — e.g. the
+ * Opt-click "Collapse All" / "Open All" gesture, and the
+ * `externalTriggers.collapse` prop.
  *
- * State-based broadcast with a version counter. Each call to
- * `setCollapseState` writes the command(s) into provider state and bumps
- * `version`. Subscribers (`CollectionNode`s) read both from context and
- * compare `version` to a `useRef`-tracked last-seen value to decide whether
- * to apply.
+ * ## Contract surface
  *
- * Why a version counter: re-broadcasting a command with identical content
- * (e.g. Collapse-All, then Collapse-All again) needs to re-fire consumer
- * effects. Identity comparison on the `commands` array alone isn't enough
- * because nothing guarantees a fresh array reference. The version counter
- * makes "this is a new broadcast" explicit.
+ * Provider state is `{ commands, version }`. Every `setCollapseState(cmds)`
+ * snapshots the commands and bumps `version`. Subscribers (every
+ * `CollectionNode`) consume the state via three named contracts:
  *
- * Why state (not pub-sub): pub-sub broadcasts only reach subscribers mounted
- * at broadcast time. A subtree-expand command targeting a not-yet-mounted
- * descendant (collapsed-at-load with `collapse={N}`) misses every level past
- * the mount frontier — see #273. With state, newly-mounted descendants read
+ * 1. **Broadcast application** — `useAppliedBroadcast(path,
+ *    hasBeenOpenedRef, animateCollapse)` walks `commands` once per new
+ *    `version`, applies the last command whose path matches this node, and
+ *    bails on subsequent renders via a version-mismatch check. Late mounts
+ *    (descendants that mount as their parent expands during a cascade)
+ *    read the still-present commands on their first render — that's what
+ *    makes Opt-click "Open All" reach past the initial mount frontier
+ *    (#273).
+ *
+ * 2. **Prop-change retires broadcast** — CollectionNode uses
+ *    `useReferenceChanged(collapseFilter)` to detect when the consumer's
+ *    derived `collapse` prop has changed. A change is fresher consumer
+ *    intent than any pending broadcast, so the node calls
+ *    `setCollapseState(null)` to retire the stale commands. Skipped on
+ *    first mount — the cascade-through-frontier behavior above relies on
+ *    freshly-mounted descendants seeing the still-set commands.
+ *
+ * 3. **User-action clears broadcast** — `setCollapseState(null)` is also
+ *    called by user-driven actions that mount a new `CollectionNode` and
+ *    don't want it to inherit a recent broadcast (otherwise "I just added
+ *    a new object, why is it collapsed?"). Two call sites, both grep-able
+ *    as `setCollapseState(null)`:
+ *      - `handleAdd` in CollectionNode.tsx
+ *      - `handleChangeDataType` in ValueNodeWrapper.tsx
+ *    External programmatic `setData` doesn't go through these paths, so
+ *    it still inherits — matches "user expressed an intent; external data
+ *    changes should respect it until the user expresses otherwise."
+ *
+ * ## Why state, not pub-sub
+ *
+ * Pub-sub broadcasts only reach subscribers mounted at broadcast time. A
+ * subtree-expand command targeting a not-yet-mounted descendant
+ * (collapsed at load with `collapse={N}`) misses every level past the
+ * mount frontier — see #273. With state, newly-mounted descendants read
  * the still-present command on their first render and cascade naturally.
  *
- * No stale-clear timer. The cascade through a deep tree can take many React
- * commits, each of which may itself render thousands of nodes — there is no
- * fixed timer that's both short enough to feel like "the broadcast was
- * transient" and long enough to cover the cascade on arbitrarily large
- * trees. So we don't try: `commands` persists in state until the next
- * broadcast overwrites it or it's explicitly cleared via
- * `setCollapseState(null)`.
+ * ## Why the version counter
  *
- * `setCollapseState(null)` clears the pending broadcast (sets `commands` to
- * null without bumping `version`). This is used by user-driven actions that
- * mount new CollectionNodes — notably `handleAdd` and
- * `handleChangeDataType`. Without the clear, the new node would inherit the
- * still-set broadcast, which is surprising ("I just added a new object,
- * why is it collapsed?"). External programmatic `setData` doesn't go
- * through those paths, so it still inherits — which matches "user
- * expressed an intent; external data changes should respect it until the
- * user expresses otherwise."
+ * Re-broadcasting a command with identical content (Collapse-All, then
+ * Collapse-All again) needs to re-fire consumer effects. Identity
+ * comparison on the `commands` array alone isn't enough because nothing
+ * guarantees a fresh array reference. The version counter makes "this is
+ * a new broadcast" explicit; consumer effects compare against a
+ * `useRef`-tracked last-seen value.
+ *
+ * No stale-clear timer. The cascade through a deep tree can take many
+ * React commits, each of which may itself render thousands of nodes —
+ * there's no fixed timer that's both short enough to feel transient and
+ * long enough to cover the cascade on arbitrarily large trees. So
+ * `commands` persists in state until the next broadcast overwrites it or
+ * it's explicitly cleared via `setCollapseState(null)`.
  */
 
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { type CollectionKey, type OnCollapseFunction, type CollapseState } from '../types'
 
 interface CollapseContext {
@@ -100,10 +132,7 @@ export const useCollapse = () => {
   return context
 }
 
-export const doesCollapseStateMatchPath = (
-  path: CollectionKey[],
-  command: CollapseState
-): boolean => {
+const doesCollapseStateMatchPath = (path: CollectionKey[], command: CollapseState): boolean => {
   if (!command.includeChildren)
     return command.path.length === path.length && command.path.every((part, i) => path[i] === part)
 
@@ -114,4 +143,74 @@ export const doesCollapseStateMatchPath = (
     if (value !== path[index]) return false
   }
   return true
+}
+
+/**
+ * Returns true on renders where `value` differs from the previous render
+ * by `Object.is` (reference identity, matching React's `useEffect`
+ * dep-array semantics). Returns false on first render. Not a deep
+ * comparison — calling with a large data object would compare references
+ * only, never contents. The ref-update happens in a `useEffect`, so a
+ * render that re-runs without committing (concurrent mode, strict mode)
+ * reads the same answer twice.
+ *
+ * Used to disambiguate "first mount" from "subsequent change" without
+ * wedging a flag ref into the surrounding effect.
+ */
+export const useReferenceChanged = <T,>(value: T): boolean => {
+  const ref = useRef(value)
+  const changed = !Object.is(ref.current, value)
+  useEffect(() => {
+    ref.current = value
+  })
+  return changed
+}
+
+/**
+ * Applies broadcast commands to a CollectionNode. Reads `version` and
+ * `commands` from the collapse context; uses a `useRef`-tracked last-seen
+ * version to fire exactly once per broadcast. Newly-mounted descendants
+ * start with `lastSeenVersionRef.current === 0`, so their first render
+ * sees a mismatch against the current `version` and applies the
+ * still-present command — that's how Opt-click "Open All" cascades past
+ * the initial mount frontier (#273).
+ *
+ * Last-matching-wins: when an array of commands targets the same node
+ * multiple times, only the last matching command is applied. Calling
+ * `animateCollapse` more than once in the same effect fire would close
+ * over render-time `collapsed` and mis-fire — React batches the
+ * `setCollapsed` between calls, so the second sees stale state.
+ *
+ * `hasBeenOpenedRef.current` is set true only when expanding. A collapse
+ * broadcast must not flip the mount gate on a never-opened node, or its
+ * descendants would mount on the next render and undo the "don't mount
+ * descendants of never-opened nodes" perf optimization.
+ *
+ * Effect deps are `[version, commands]` only. `path` and `animateCollapse`
+ * are closed over and captured fresh on every fire — effects re-create
+ * their closure on each run. Listing them would fire the effect on every
+ * local collapse toggle and every parent re-render that hands down a new
+ * data ref; on large trees that's significant React scheduling overhead
+ * even though the version check would early-return.
+ */
+export const useAppliedBroadcast = (
+  path: CollectionKey[],
+  hasBeenOpenedRef: React.RefObject<boolean>,
+  animateCollapse: (collapse: boolean) => void
+) => {
+  const { commands, version } = useCollapse()
+  const lastSeenVersionRef = useRef(0)
+  useEffect(() => {
+    if (version === lastSeenVersionRef.current) return
+    lastSeenVersionRef.current = version
+    if (!commands) return
+    let lastMatching: CollapseState | undefined
+    for (const cmd of commands) {
+      if (doesCollapseStateMatchPath(path, cmd)) lastMatching = cmd
+    }
+    if (!lastMatching) return
+    if (!lastMatching.collapsed) hasBeenOpenedRef.current = true
+    animateCollapse(lastMatching.collapsed)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [version, commands])
 }

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,4 +1,4 @@
 export * from './ThemeProvider'
 export { TreeStateProvider } from './TreeStateProvider'
 export { useEditing } from './EditingProvider'
-export { useCollapse, doesCollapseStateMatchPath } from './CollapseProvider'
+export { useCollapse, useAppliedBroadcast, useReferenceChanged } from './CollapseProvider'


### PR DESCRIPTION
## Summary

Pure refactor of the collapse broadcast mechanism — no behavior changes, no API changes, 232 tests pass unchanged. Closes #276.

The three contracts identified in #276 are now named and isolated so the collapse-related code in [CollectionNode.tsx](src/CollectionNode.tsx) reads top-to-bottom and §16 can replace the per-node broadcast effect with a per-path atomic store without disturbing the call sites.

- **Contract #1 — Broadcast application.** ~25 lines of inline effect + `lastSeenVersionRef` + last-matching-wins loop + closure-deps eslint-disable in CollectionNode collapses to a single `useAppliedBroadcast(path, hasBeenOpened, animateCollapse)` call. The hook lives in [CollapseProvider.tsx](src/contexts/CollapseProvider.tsx) next to the state it consumes.
- **Contract #2 — Prop-change retires broadcast.** The `collapseFilterHasChangedRef` flag wedged into the `[collapseFilter]` effect becomes `useReferenceChanged(collapseFilter)`. The new hook is generic, compares via `Object.is` (matching React's `useEffect` dep-array semantics — not a deep comparison; JSDoc spells this out so a future caller doesn't pass a large data object expecting semantic equality), and updates its internal ref in a `useEffect` so strict-mode double-render is safe.
- **Contract #3 — User-action clears broadcast.** The two `setCollapseState(null)` call sites (`handleAdd` in CollectionNode, `handleChangeDataType` in ValueNodeWrapper) keep the inline call — two sites is below the threshold where a named helper earns its keep — and each gets a one-line "Contract #3" comment pointing back to the provider doc, which names both sites. `grep "setCollapseState(null)"` remains the canonical "find all clears" query.
- **Provider doc refresh.** Top-of-file comment in [CollapseProvider.tsx](src/contexts/CollapseProvider.tsx) now describes the **contract surface** (the three named operations, when they fire, why) rather than the implementation. Implementation details (last-matching-wins, why `[version, commands]` deps only) moved into `useAppliedBroadcast`'s JSDoc.
- **Privacy tightening.** `doesCollapseStateMatchPath` was only consumed by the inline effect in CollectionNode; now that its only caller is `useAppliedBroadcast` in the same file, it's no longer exported. The `contexts/index.ts` re-export is swapped for `useAppliedBroadcast` + `useReferenceChanged`.

## Bundle delta

| Bundle | Before | After | Δ |
|---|---|---|---|
| `index.esm.js` | 54,980 B | 55,072 B | +92 B |
| `index.cjs.js` | 56,310 B | 56,403 B | +93 B |

The cost of the `useReferenceChanged` ref-update effect. Within the "handful of bytes" target.

## Test plan

- [x] `pnpm test` — 231 passed, 1 todo, 0 failed (unchanged from base).
- [x] `pnpm lint` clean.
- [x] `pnpm compile` clean (`tsc --noEmit` + `ts-prune`).
- [x] `pnpm build` succeeds; bundle deltas as above.
- [ ] Manual: load demo with `scripts/generate-test-data.mjs` output (138k nodes, 15 levels) + `collapse={2}` — Opt-click "Open All" from a closed root expands every level (the #273 cascade-through-frontier behaviour); change a string's type to "object" after Opt-click Collapse-All — newly-mounted CollectionNode uses default state, doesn't inherit Collapse-All.

## Out of scope

- Per-node `React.memo`, callback stability, atomic store — all §16.
- API changes. `setCollapseState`, `useCollapse`, the context surface — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)