### PR TITLE
§17 Phase 0: canonical API types (staging, unused) — #295

### DIFF
--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -1,0 +1,218 @@
+/**
+ * §17 API STANDARDISATION — CANONICAL TYPES (staging)
+ *
+ * The consumer-facing API expressed as the three-category model plus an
+ * imperative command handle:
+ *
+ *   - Category 1 — Gates: run *before* an action, answer "should this proceed /
+ *     am I taking over?" (`allow*`, `onEventIntercept`). Return `boolean`/`void`.
+ *   - Category 2 — Result producers: run *at commit*, answer "accept / reject /
+ *     transform?" (`onUpdate`, `onChange`). Return the canonical result shape.
+ *   - Category 3 — Observers: run *after*, return ignored (`onError`,
+ *     `onEditEvent`, `onCollapse`, `onCopy`).
+ *   - Category 4 — Imperative commands: the `editorRef` handle.
+ *
+ * Every callback receives a flat `NodeData<T>` (reused from `./types`) with
+ * category-specific fields and, where relevant, an `event` discriminant spread
+ * on top. `value` (current node value) and `fullData` (current document) cover
+ * "current", so update payloads add only the *new* bit (`newValue`/`newKey`/…).
+ *
+ * These types are deliberately unused for now — each is wired into the
+ * implementation (replacing its legacy counterpart in `./types`) by a later
+ * §17 phase.
+ */
+
+import type { JsonData, CollectionKey, ValueData, CopyType, NodeData } from './types'
+
+/* ============================================================================
+ * Shared building blocks
+ * ========================================================================== */
+
+/**
+ * The definitive error code list, split by surfacing channel:
+ *   - Group A (mutation / edit flow)   → `onError` observer + `UpdateResult.error`
+ *   - Group B (imperative command flow) → `CommandResult.error` (the return value)
+ */
+export type JsonEditorErrorCode =
+  // Group A — mutation / edit flow
+  | 'UPDATE_ERROR' // an edit was rejected, or an internal failure occurred
+  | 'ADD_ERROR' // an add was rejected
+  | 'DELETE_ERROR' // a delete was rejected
+  | 'KEY_EXISTS' // a new/renamed key collides with an existing sibling
+  | 'INVALID_JSON' // raw JSON typed into the editor failed to parse
+  // Group B — imperative command flow (Category 4)
+  | 'PATH_NOT_FOUND' // a command targeted a path that doesn't exist in the current data
+  | 'RESTRICTED' // a command's action is blocked by an `allow*` filter
+
+/** The one canonical error shape, used everywhere an error is produced or reported. */
+export interface JsonEditorError {
+  code: JsonEditorErrorCode
+  message: string
+}
+
+/* ============================================================================
+ * Category 1 — Gates (run before, decide whether to proceed)
+ * ========================================================================== */
+
+/**
+ * Hard gate: permission. `true` = allowed. May be async (e.g. a server
+ * permission check) — the library awaits, and awaiting a sync return is free.
+ */
+export type FilterFunction<T = JsonData> = (node: NodeData<T>) => boolean | Promise<boolean>
+
+/**
+ * Soft gate: a user-initiated action about to start. Flat `NodeData` plus an
+ * `event` discriminant. `delete`/`move` are instant — the intercept *is* the
+ * click (before the one-shot delete) / the drop.
+ */
+export type InterceptableEvent<T = JsonData> = NodeData<T> &
+  (
+    | { event: 'startEdit' }
+    | { event: 'startRename' }
+    | { event: 'startAdd' }
+    | { event: 'delete' }
+    | { event: 'move' }
+  )
+
+/** `true` (or any non-`void`) = "I'll take it over"; `void`/`false` = proceed. */
+export type EventInterceptFunction<T = JsonData> = (
+  e: InterceptableEvent<T>
+) => boolean | void | Promise<boolean | void>
+
+/* ============================================================================
+ * Category 2 — Result producers (run at commit, accept / reject / transform)
+ * ========================================================================== */
+
+/** The one canonical update result. */
+export type UpdateResult<T = JsonData> =
+  | true // proceed
+  | void
+  | undefined
+  | false // reject (generic error)
+  | {
+      value?: T // override the committed value
+      error?: string | JsonEditorError // reject with message (a bare string is wrapped)
+      cancel?: true // silent abort — no commit, no error
+    }
+
+/**
+ * `NodeData` carries the CURRENT identity/value; the event-specific field
+ * carries the NEW bit; `newData` is always the resulting document. `rename` and
+ * `move` are first-class events even though both are delete+add under the hood —
+ * they arrive via distinct user interactions and carry distinct deltas.
+ */
+export type UpdateFunctionProps<T = JsonData> = NodeData<T> & { newData: T } & (
+    | { event: 'edit'; newValue: unknown } // value changes (incl. type change)
+    // For `add`, `NodeData` describes the new node's *position* (`path`/`key`);
+    // `value` is unset until commit.
+    | { event: 'add'; newValue: unknown }
+    | { event: 'delete' } // `newData` reflects the removal
+    | { event: 'rename'; newKey: CollectionKey } // `NodeData.key`/`path` = OLD; use `newKey` + `newData`
+    | { event: 'move'; newPath: CollectionKey[] } // `NodeData.path` = source; `newPath` = destination
+  )
+
+/** One `onUpdate` — branch on `event`. Fires for user- and command-driven alike. */
+export type UpdateFunction<T = JsonData> = (
+  props: UpdateFunctionProps<T>
+) => UpdateResult<T> | Promise<UpdateResult<T>>
+
+/** Transform (distinct contract — returns the value, not a result). */
+export type OnChangeFunction<T = JsonData> = (
+  props: NodeData<T> & { newValue: ValueData }
+) => ValueData
+
+/* ============================================================================
+ * Category 3 — Observers (run after, return ignored)
+ * ========================================================================== */
+
+/** After any error condition (Group A codes). */
+export type OnErrorFunction<T = JsonData> = (
+  props: NodeData<T> & { error: JsonEditorError; errorValue: JsonData }
+) => void
+
+/**
+ * The complete interaction-lifecycle stream: value-edit, key-rename and add
+ * sessions (start/confirm/cancel), plus the instant `delete`/`move` (one event
+ * each). `confirmRename` carries `{ oldKey, newKey }`.
+ */
+export type EditEvent<T = JsonData> = NodeData<T> &
+  (
+    | { event: 'startEdit' }
+    | { event: 'confirmEdit' }
+    | { event: 'cancelEdit' }
+    | { event: 'startRename' }
+    | { event: 'confirmRename'; oldKey: CollectionKey; newKey: CollectionKey }
+    | { event: 'cancelRename' }
+    | { event: 'startAdd' }
+    | { event: 'confirmAdd' }
+    | { event: 'cancelAdd' }
+    | { event: 'delete' }
+    | { event: 'move' }
+  )
+
+export type OnEditEventFunction<T = JsonData> = (e: EditEvent<T>) => void
+
+/** On collapse/expand (user click or `editorRef.collapse`). */
+export type OnCollapseFunction<T = JsonData> = (
+  props: NodeData<T> & { collapsed: boolean; includeChildren: boolean }
+) => void
+
+/** After a copy-to-clipboard. Enablement is the `allowClipboard` boolean (Cat 1). */
+export type OnCopyFunction<T = JsonData> = (
+  props: NodeData<T> & {
+    success: boolean
+    stringValue: string
+    type: CopyType
+    error?: JsonEditorError
+  }
+) => void
+
+/* ============================================================================
+ * Category 4 — Imperative commands (the `editorRef` handle)
+ * ========================================================================== */
+
+/**
+ * Strictly binary: did the command run, or was it refused? All descriptive
+ * metadata comes from the observer that fires as a result.
+ */
+export type CommandResult = { success: true } | { success: false; error: JsonEditorError }
+
+// (No `<T>` generic yet — no method references the document type. A later phase
+// adds it if/when typed payloads are threaded through the commands.)
+export interface JsonEditorHandle {
+  // --- Session openers: enter an interactive session (open the input) at a
+  //     node; no value supplied. Sync (just opens). The eventual confirm runs
+  //     the pipeline. Distinct starts, SHARED confirm/cancel (one session open).
+  startEdit(opts: { path: CollectionKey[]; overrideRestrictions?: boolean }): CommandResult
+  startRename(opts: { path: CollectionKey[]; overrideRestrictions?: boolean }): CommandResult
+  startAdd(opts: { path: CollectionKey[]; overrideRestrictions?: boolean }): CommandResult
+  confirm(): Promise<CommandResult> // commit the active session (runs onUpdate)
+  cancel(): void // abort the active session
+
+  // --- Direct ("all-in-one") mutators: do the whole mutation with values
+  //     provided, no UI session. Run the pipeline → async.
+  delete(opts: { path: CollectionKey[]; overrideRestrictions?: boolean }): Promise<CommandResult>
+  edit(opts: {
+    path: CollectionKey[]
+    value: unknown
+    overrideRestrictions?: boolean
+  }): Promise<CommandResult>
+  add(opts: {
+    path: CollectionKey[]
+    value: unknown
+    overrideRestrictions?: boolean
+  }): Promise<CommandResult>
+  rename(opts: {
+    path: CollectionKey[]
+    newKey: CollectionKey
+    overrideRestrictions?: boolean
+  }): Promise<CommandResult>
+  move(opts: {
+    from: CollectionKey[]
+    to: CollectionKey[]
+    overrideRestrictions?: boolean
+  }): Promise<CommandResult>
+
+  // --- Non-mutating
+  collapse(opts: { path: CollectionKey[]; collapsed?: boolean; includeChildren?: boolean }): void
+}

--- a/test/apiTypes.test.ts
+++ b/test/apiTypes.test.ts
@@ -1,0 +1,125 @@
+/**
+ * §17 API standardisation — Phase 0 compile-check.
+ *
+ * The canonical types in `src/apiTypes.ts` land unused, so nothing in the
+ * `files: ["src/index.ts"]` graph type-checks them. This file is their typecheck
+ * path: ts-jest runs full diagnostics on every `.test.ts`, so the sample typed
+ * values below — especially the exhaustive `switch (props.event)` — fail
+ * compilation (turning `pnpm test` red) if any union stops discriminating or a
+ * field shape drifts from the spec.
+ *
+ * It is NOT a behavioural test — the flows themselves arrive with each later
+ * phase's implementation.
+ */
+
+import type {
+  JsonEditorError,
+  JsonEditorErrorCode,
+  FilterFunction,
+  EventInterceptFunction,
+  UpdateFunction,
+  OnChangeFunction,
+  OnErrorFunction,
+  OnEditEventFunction,
+  OnCollapseFunction,
+  OnCopyFunction,
+  CommandResult,
+  JsonEditorHandle,
+} from '../src/apiTypes'
+import type { JsonData } from '../src/types'
+
+// --- Cat 1: async-capable gates -------------------------------------------
+
+const allow: FilterFunction = (node) => node.path.length > 0
+const allowAsync: FilterFunction = async (node) => node.level > 0
+
+const intercept: EventInterceptFunction = (e) => {
+  // The `event` discriminant narrows; `delete`/`move` are instant.
+  switch (e.event) {
+    case 'startEdit':
+    case 'startRename':
+    case 'startAdd':
+      return // proceed
+    case 'delete':
+    case 'move':
+      return true // take over
+  }
+}
+
+// --- Cat 2: result producer — exhaustive event narrowing ------------------
+
+const onUpdate: UpdateFunction = (props) => {
+  // Each branch must expose exactly its event-specific delta field.
+  switch (props.event) {
+    case 'edit':
+      return { value: props.newValue as JsonData }
+    case 'add':
+      return props.newValue === undefined ? { cancel: true } : true
+    case 'delete':
+      return // proceed (no extra field on this branch)
+    case 'rename':
+      // bare-string error shorthand lives inside the object, not at top level
+      return props.newKey === '' ? { error: 'Empty key' } : { value: props.newData }
+    case 'move':
+      return props.newPath.length === 0 ? false : undefined
+  }
+}
+
+const onChange: OnChangeFunction = (props) => props.newValue
+
+// --- Cat 3: observers ------------------------------------------------------
+
+const onError: OnErrorFunction = (props) => {
+  void props.error.code
+  void props.errorValue
+}
+
+const onEditEvent: OnEditEventFunction = (e) => {
+  // `confirmRename` is the only variant carrying old/new keys.
+  if (e.event === 'confirmRename') void `${String(e.oldKey)}→${String(e.newKey)}`
+}
+
+const onCollapse: OnCollapseFunction = (props) => void (props.collapsed && props.includeChildren)
+
+const onCopy: OnCopyFunction = (props) => void (props.success && props.type)
+
+// --- Shared: error shape ---------------------------------------------------
+
+const code: JsonEditorErrorCode = 'PATH_NOT_FOUND'
+const error: JsonEditorError = { code, message: 'gone' }
+
+// --- Cat 4: imperative handle + binary result discrimination --------------
+
+const describeResult = (r: CommandResult): string =>
+  r.success ? 'ok' : r.error.message // `error` only exists on the failure branch
+
+const handle: JsonEditorHandle = {
+  startEdit: () => ({ success: true }),
+  startRename: () => ({ success: true }),
+  startAdd: () => ({ success: false, error }),
+  confirm: async () => ({ success: true }),
+  cancel: () => undefined,
+  delete: async () => ({ success: true }),
+  edit: async () => ({ success: true }),
+  add: async () => ({ success: true }),
+  rename: async () => ({ success: true }),
+  move: async () => ({ success: true }),
+  collapse: () => undefined,
+}
+
+test('§17 API types compile', () => {
+  // Reference the samples so the file is a real module, not dead code.
+  expect([
+    allow,
+    allowAsync,
+    intercept,
+    onUpdate,
+    onChange,
+    onError,
+    onEditEvent,
+    onCollapse,
+    onCopy,
+    handle,
+    describeResult,
+  ]).toHaveLength(11)
+})


### PR DESCRIPTION
Phase 0 of the §17 API standardisation umbrella (#289). Closes #295.

Lands the §17 three-category model as TypeScript types under their **final names**, in a new staging file that nothing imports yet. **No behaviour change, no public-API change** (not re-exported from `index.ts`), **no demo change** — each type is wired into the implementation (replacing its legacy counterpart in `types.ts`) by a later phase.

## What's here

- **`src/apiTypes.ts`** — `JsonEditorError` + `JsonEditorErrorCode` (Group A mutation/edit · Group B command); the async-capable `FilterFunction`; the discriminated `InterceptableEvent` / `UpdateFunctionProps` / `EditEvent` unions; `UpdateResult`; the Cat-3 observers (`OnErrorFunction`, `OnEditEventFunction`, `OnCollapseFunction`, `OnCopyFunction`); and the `CommandResult` / `JsonEditorHandle` imperative surface.
- **`test/apiTypes.test.ts`** — compile-check + sample usage (no new dependency). Because `apiTypes.ts` sits outside the `files: ["src/index.ts"]` graph that `tsc` walks, ts-jest type-checking this test is its *only* typecheck path: a malformed union (e.g. an event branch that stops narrowing) fails `pnpm test`. It caught one real shape detail during development — confirming the bare-string error shorthand lives inside `{ error: ... }`, not at the top of `UpdateResult` (comment 17).

## Deviation from the §17 draft

`JsonEditorHandle` ships **without** the `<T>` generic the draft showed: no method references `T`, so ESLint flags it unused. Added a comment; a later phase reintroduces it if/when typed payloads thread through the commands.

## Verification

- `pnpm lint` clean
- `pnpm compile` clean (`tsc --noEmit` + `ts-prune`; no `apiTypes.ts` entries — it's correctly outside the entry graph)
- `pnpm test` — 265 passed across 13 suites, including the new compile-check

No changeset: nothing published or exported changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)