### PR TITLE
§17: clipboard split — allowClipboard + onCopy (#296)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ This is a reference list of *all* possible props, divided into related sections.
 | `onAdd`           | `UpdateFunction`        | none    | A function to run whenever a new property is **added**.                                                                             |
 | `onChange`        | `OnChangeFunction`      | none    | A function to modify/constrain user input as they type — see [OnChange functions](#onchange-function).                              |
 | `onError`         | `OnErrorFunction`       | none    | A function to run whenever the component reports an error — see [OnErrorFunction](#onerror-function).                               |
-| `enableClipboard` | `boolean\|CopyFunction` | `true`  | Enable or disable the "Copy to clipboard" button in the UI. — see [Copy Function](#copy-function)                                   |
+| `allowClipboard`  | `boolean`               | `true`  | Enable or disable the "Copy to clipboard" button in the UI.                                                                         |
+| `onCopy`          | `OnCopyFunction`        | none    | A function to run whenever an item is **copied** to the clipboard — see [Copy Function](#copy-function).                            |
 
 </details>
 <details>
@@ -433,18 +434,16 @@ Normally, the component will display simple error messages whenever an error con
 
 ### Copy Function
 
-A similar callback can be run whenever an item is **copied** to the clipboard (if passed to the `enableClipboard` prop), but with a slightly different input object:
+The `onCopy` callback runs whenever an item is **copied** to the clipboard. It receives the standard [node data](#filter-functions) (`key`, `path`, `value`, `fullData`, etc.) with the following additional fields spread on top:
 
 ```js
 {
-    key          // name of the property being copied  
-    path         // path to the property
-    value        // the value copied to the clipboard
-    type         // Either "path" or "value" depending on whether "Cmd/Ctrl" was pressed 
-    stringValue  // A nicely stringified version of `value`  
+    // ...standard node data (key, path, value, ...)
+    type         // Either "path" or "value" depending on whether "Cmd/Ctrl" was pressed
+    stringValue  // A nicely stringified version of the copied value
                  // (i.e. what the clipboard actually receives)
-    success      // true/false -- whether clipboard copy action actually succeeded
-    errorMessage // Error detail if `success === false`
+    success      // true/false -- whether the clipboard copy action actually succeeded
+    error        // `{ message }` with the failure detail when `success === false`
 }
 ```
 
@@ -1364,7 +1363,7 @@ A few helper functions, components and types that might be useful in your own im
 - `ThemeInput`: input type for the `theme` prop
 - `JsonEditorProps<T>`: all input props for the Json Editor component. Generic on the data type — see [Typed data](#typed-data).
 - `JsonData`: main `data` object -- any valid JSON structure. Used as the default for `T`.
-- [`UpdateFunction`](#update-functions), [`OnChangeFunction`](#onchange-function), [`OnErrorFunction`](#onerror-function) [`FilterFunction`](#filter-functions), [`CopyFunction`](#copy-function), [`SearchFilterFunction`](#searchfiltering), [`OnEditEventFunction`](#event-callbacks), [`OnCollapseFunction`](#event-callbacks), [`CompareFunction`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort),[`TypeFilterFunction`](#filter-functions), [`NewKeyOptionsFunction`](#new-key-restrictions--default-values), [`DefaultValueFunction`](#new-key-restrictions--default-values)
+- [`UpdateFunction`](#update-functions), [`OnChangeFunction`](#onchange-function), [`OnErrorFunction`](#onerror-function) [`FilterFunction`](#filter-functions), [`OnCopyFunction`](#copy-function), [`SearchFilterFunction`](#searchfiltering), [`OnEditEventFunction`](#event-callbacks), [`OnCollapseFunction`](#event-callbacks), [`CompareFunction`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort),[`TypeFilterFunction`](#filter-functions), [`NewKeyOptionsFunction`](#new-key-restrictions--default-values), [`DefaultValueFunction`](#new-key-restrictions--default-values)
 - [`CustomNodeDefinition`](#custom-nodes), [`CustomTextDefinitions`](#custom-text), [`CustomTextFunction`](#custom-text), [`JsonEditorHandle`](#imperative-handle-editorref), [`JsonViewerHandle`](#imperative-handle-editorref), [`StartEditOptions`](#imperative-handle-editorref): input types of the respective props
 - `TranslateFunction`: function that takes a [localisation](#localisation) key and returns a translated string
 - `LocalisedString`: keys for the [`translations`](#localisation) object

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -252,23 +252,23 @@ function App() {
 
   // Stable references so the JsonEditor's memoized nodes can bail out: an inline
   // `theme` array would churn the theme context (re-rendering every node), and
-  // an inline `enableClipboard` would churn the per-node prop comparison.
+  // an inline `onCopy` would churn the per-node prop comparison.
   const editorTheme = useMemo(
     () => [theme, dataDefinition?.styles ?? {}, { container: { paddingTop: '1em' } }],
     [theme, dataDefinition]
   )
 
-  const enableClipboard = useCallback(
+  const onCopy = useCallback(
     ({
       stringValue,
       type,
       success,
-      errorMessage,
+      error,
     }: {
-      stringValue: unknown
+      stringValue: string
       type: 'value' | 'path'
       success: boolean
-      errorMessage: string | null
+      error?: { message: string }
     }) =>
       success
         ? toast({
@@ -280,7 +280,7 @@ function App() {
           })
         : toast({
             title: 'Problem copying to clipboard',
-            description: errorMessage,
+            description: error?.message,
             status: 'error',
             duration: 5000,
             isClosable: true,
@@ -522,7 +522,8 @@ function App() {
                   showCollectionCount={
                     showCount === 'Yes' ? true : showCount === 'When closed' ? 'when-closed' : false
                   }
-                  enableClipboard={allowCopy ? enableClipboard : false}
+                  allowClipboard={allowCopy}
+                  onCopy={onCopy}
                   restrictEdit={restrictEdit}
                   // restrictEdit={(nodeData) => !(typeof nodeData.value === 'string')}
                   restrictDelete={restrictDelete}

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -16,6 +16,7 @@ If you only have a few minutes, these are the changes most likely to affect exis
 | `JsonEditor` is now generic on the data type (`JsonEditor<T>`) | No action needed — defaults to `JsonData`, source-compatible. Opt in by writing `<JsonEditor<MyShape> ... />` |
 | `setData` is now required; `viewOnly` removed; new `JsonViewer` export | Switch read-only usage to `<JsonViewer>`; replace `viewOnly={cond}` with the relevant `restrict*` toggles, including `restrictDrag` if drag was enabled — see §6 |
 | `externalTriggers` prop replaced by the `editorRef` imperative handle | Use a `useRef<JsonEditorHandle>` and call `editorRef.current.collapse/startEdit/cancelEdit/confirmEdit` — see §7 |
+| `enableClipboard` split into `allowClipboard` (boolean) + `onCopy` (callback); `CopyFunction` → `OnCopyFunction` | Rename the boolean to `allowClipboard`; move any copy callback to `onCopy` (`errorMessage` → `error.message`) — see §8 |
 
 ---
 
@@ -286,6 +287,41 @@ Two behaviours of `startEdit` worth noting:
 - It **auto-reveals** a target collapsed below the current view: collapsed ancestors expand so the node becomes editable.
 
 `JsonViewer` also accepts `editorRef`, but its `JsonViewerHandle` exposes only `collapse` — editing actions would bypass the read-only contract, so they aren't surfaced.
+
+---
+
+## 8. `enableClipboard` split into `allowClipboard` + `onCopy`
+
+The dual-purpose `enableClipboard?: boolean | CopyFunction` prop is split into two single-purpose props: `allowClipboard?: boolean` (default `true`) controls whether the copy button shows, and the new `onCopy?: OnCopyFunction` observer runs after a copy. The `CopyFunction` type is removed in favour of `OnCopyFunction`.
+
+**Why:** one prop doing two unrelated jobs (a boolean toggle *and* a callback) was awkward to type and document. The split is single-purpose, and `onCopy` now receives the same flat [`NodeData`](https://carlosnz.github.io/json-edit-react/) payload every other callback gets.
+
+### Migration
+
+If you only enabled/disabled the button:
+
+```diff
+- <JsonEditor data={data} setData={setData} enableClipboard={false} />
++ <JsonEditor data={data} setData={setData} allowClipboard={false} />
+```
+
+If you passed a callback (it both enabled the button *and* observed copies):
+
+```diff
+- import { JsonEditor, type CopyFunction } from 'json-edit-react'
++ import { JsonEditor, type OnCopyFunction } from 'json-edit-react'
+
+- const handleCopy: CopyFunction = ({ stringValue, type, success, errorMessage }) => {
+-   if (!success) console.error(errorMessage)
++ const handleCopy: OnCopyFunction = ({ stringValue, type, success, error }) => {
++   if (!success) console.error(error?.message)
+  }
+
+- <JsonEditor data={data} setData={setData} enableClipboard={handleCopy} />
++ <JsonEditor data={data} setData={setData} onCopy={handleCopy} />
+```
+
+Payload changes on the callback object: the explicit `key` / `path` / `value` fields are now part of the spread `NodeData` (so `key`, `path`, `value`, `fullData`, … are all still available); `errorMessage: string | null` becomes `error?: { message: string }` (present only when `success` is `false`).
 
 ---
 

--- a/src/ButtonPanels.tsx
+++ b/src/ButtonPanels.tsx
@@ -6,11 +6,11 @@ import { type TranslateFunction } from './localisation'
 import {
   type CollectionKey,
   type CollectionDataType,
-  type CopyFunction,
   type CopyType,
   type NodeData,
   type CustomButtonDefinition,
   type KeyboardControlsFull,
+  type OnCopyFunction,
   JsonData,
   OnEditEventFunction,
 } from './types'
@@ -19,7 +19,8 @@ import { getModifier } from './utils/keyboard'
 interface EditButtonProps {
   startEdit?: () => void
   handleDelete?: () => void
-  enableClipboard: boolean | CopyFunction
+  allowClipboard: boolean
+  onCopy?: OnCopyFunction
   handleAdd?: (newKey: string) => void
   type?: CollectionDataType
   nodeData: NodeData
@@ -45,7 +46,8 @@ export const EditButtons: React.FC<EditButtonProps> = ({
   startEdit,
   handleDelete,
   handleAdd,
-  enableClipboard,
+  allowClipboard,
+  onCopy,
   type,
   customButtons,
   nodeData,
@@ -69,7 +71,7 @@ export const EditButtons: React.FC<EditButtonProps> = ({
   // state value.
   const [addingKeyState, setAddingKeyState] = useState<string[] | boolean>(false)
 
-  const { key, path, value: data } = nodeData
+  const { path, value: data } = nodeData
 
   const hasKeyOptionsList = Array.isArray(addingKeyState)
 
@@ -121,7 +123,7 @@ export const EditButtons: React.FC<EditButtonProps> = ({
     let stringValue = ''
     let success: boolean
     let errorMessage: string | null = null
-    if (enableClipboard) {
+    if (allowClipboard) {
       const modifier = getModifier(e)
       if (modifier && keyboardControls.clipboardModifier.includes(modifier)) {
         value = stringifyPath(path)
@@ -132,16 +134,13 @@ export const EditButtons: React.FC<EditButtonProps> = ({
         stringValue = typeof value === 'object' ? jsonStringify(data) : String(value)
       }
       if (!navigator.clipboard) {
-        if (typeof enableClipboard === 'function')
-          enableClipboard({
-            success: false,
-            value,
-            stringValue,
-            path,
-            key,
-            type: copyType,
-            errorMessage: "Can't access clipboard API",
-          })
+        onCopy?.({
+          ...nodeData,
+          success: false,
+          stringValue,
+          type: copyType,
+          error: { message: "Can't access clipboard API" },
+        })
         return
       }
       navigator.clipboard
@@ -152,17 +151,13 @@ export const EditButtons: React.FC<EditButtonProps> = ({
           errorMessage = err.message
         })
         .finally(() => {
-          if (typeof enableClipboard === 'function') {
-            enableClipboard({
-              success,
-              errorMessage,
-              value,
-              stringValue,
-              path,
-              key,
-              type: copyType,
-            })
-          }
+          onCopy?.({
+            ...nodeData,
+            success,
+            stringValue,
+            type: copyType,
+            error: success ? undefined : { message: errorMessage ?? 'Copy failed' },
+          })
         })
     }
   }
@@ -173,7 +168,7 @@ export const EditButtons: React.FC<EditButtonProps> = ({
       style={{ opacity: addingKeyState ? 1 : undefined }}
       onClick={(e) => e.stopPropagation()}
     >
-      {enableClipboard && (
+      {allowClipboard && (
         <div
           onClick={handleCopy}
           className="jer-copy-pulse"

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -46,7 +46,8 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
     collapseFilter,
     collapseAnimationTime,
     onMove,
-    enableClipboard,
+    allowClipboard,
+    onCopy,
     onEditEvent,
     showIconTooltips,
     searchFilter,
@@ -479,7 +480,8 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
       }
       handleAdd={canAdd ? handleAdd : undefined}
       handleDelete={canDelete ? handleDelete : undefined}
-      enableClipboard={enableClipboard}
+      allowClipboard={allowClipboard}
+      onCopy={onCopy}
       type={collectionType}
       nodeData={nodeData}
       translate={translate}

--- a/src/JsonEditor.tsx
+++ b/src/JsonEditor.tsx
@@ -96,7 +96,8 @@ const Editor: React.FC<JsonEditorProps<JsonData>> = ({
   onError,
   onEditEvent,
   showErrorMessages = true,
-  enableClipboard = true,
+  allowClipboard = true,
+  onCopy,
   indent = 2,
   collapse = false,
   collapseAnimationTime = 300, // must be equivalent to CSS value
@@ -207,6 +208,7 @@ const Editor: React.FC<JsonEditorProps<JsonData>> = ({
   const onErrorStable = useStableCallback(onError)
   const onCollapseStable = useStableCallback(onCollapse)
   const onEditEventStable = useStableCallback(onEditEvent)
+  const onCopyStable = useStableCallback(onCopy)
 
   // Common method for handling data update. It runs the updated data through
   // provided "onUpdate" function, then updates data state or returns error
@@ -507,7 +509,8 @@ const Editor: React.FC<JsonEditorProps<JsonData>> = ({
     canDragOnto: false, // can't drag onto outermost container
     searchFilter,
     searchText: debouncedSearchText,
-    enableClipboard,
+    allowClipboard,
+    onCopy: onCopyStable,
     keySort,
     sort,
     showArrayIndices,

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -35,7 +35,8 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
     onDelete,
     onChange,
     onMove,
-    enableClipboard,
+    allowClipboard,
+    onCopy,
     canDragOnto,
     restrictTypeSelection,
     searchFilter,
@@ -452,7 +453,8 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
                     : undefined
                 }
                 handleDelete={canDelete ? handleDelete : undefined}
-                enableClipboard={enableClipboard}
+                allowClipboard={allowClipboard}
+                onCopy={onCopy}
                 translate={translate}
                 customButtons={props.customButtons}
                 nodeData={nodeData}

--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -1,0 +1,218 @@
+/**
+ * §17 API STANDARDISATION — CANONICAL TYPES (staging)
+ *
+ * The consumer-facing API expressed as the three-category model plus an
+ * imperative command handle:
+ *
+ *   - Category 1 — Gates: run *before* an action, answer "should this proceed /
+ *     am I taking over?" (`allow*`, `onEventIntercept`). Return `boolean`/`void`.
+ *   - Category 2 — Result producers: run *at commit*, answer "accept / reject /
+ *     transform?" (`onUpdate`, `onChange`). Return the canonical result shape.
+ *   - Category 3 — Observers: run *after*, return ignored (`onError`,
+ *     `onEditEvent`, `onCollapse`, `onCopy`).
+ *   - Category 4 — Imperative commands: the `editorRef` handle.
+ *
+ * Every callback receives a flat `NodeData<T>` (reused from `./types`) with
+ * category-specific fields and, where relevant, an `event` discriminant spread
+ * on top. `value` (current node value) and `fullData` (current document) cover
+ * "current", so update payloads add only the *new* bit (`newValue`/`newKey`/…).
+ *
+ * These types are deliberately unused for now — each is wired into the
+ * implementation (replacing its legacy counterpart in `./types`) by a later
+ * §17 phase.
+ */
+
+import type { JsonData, CollectionKey, ValueData, CopyType, NodeData } from './types'
+
+/* ============================================================================
+ * Shared building blocks
+ * ========================================================================== */
+
+/**
+ * The definitive error code list, split by surfacing channel:
+ *   - Group A (mutation / edit flow)   → `onError` observer + `UpdateResult.error`
+ *   - Group B (imperative command flow) → `CommandResult.error` (the return value)
+ */
+export type JsonEditorErrorCode =
+  // Group A — mutation / edit flow
+  | 'UPDATE_ERROR' // an edit was rejected, or an internal failure occurred
+  | 'ADD_ERROR' // an add was rejected
+  | 'DELETE_ERROR' // a delete was rejected
+  | 'KEY_EXISTS' // a new/renamed key collides with an existing sibling
+  | 'INVALID_JSON' // raw JSON typed into the editor failed to parse
+  // Group B — imperative command flow (Category 4)
+  | 'PATH_NOT_FOUND' // a command targeted a path that doesn't exist in the current data
+  | 'RESTRICTED' // a command's action is blocked by an `allow*` filter
+
+/** The one canonical error shape, used everywhere an error is produced or reported. */
+export interface JsonEditorError {
+  code: JsonEditorErrorCode
+  message: string
+}
+
+/* ============================================================================
+ * Category 1 — Gates (run before, decide whether to proceed)
+ * ========================================================================== */
+
+/**
+ * Hard gate: permission. `true` = allowed. May be async (e.g. a server
+ * permission check) — the library awaits, and awaiting a sync return is free.
+ */
+export type FilterFunction<T = JsonData> = (node: NodeData<T>) => boolean | Promise<boolean>
+
+/**
+ * Soft gate: a user-initiated action about to start. Flat `NodeData` plus an
+ * `event` discriminant. `delete`/`move` are instant — the intercept *is* the
+ * click (before the one-shot delete) / the drop.
+ */
+export type InterceptableEvent<T = JsonData> = NodeData<T> &
+  (
+    | { event: 'startEdit' }
+    | { event: 'startRename' }
+    | { event: 'startAdd' }
+    | { event: 'delete' }
+    | { event: 'move' }
+  )
+
+/** `true` (or any non-`void`) = "I'll take it over"; `void`/`false` = proceed. */
+export type EventInterceptFunction<T = JsonData> = (
+  e: InterceptableEvent<T>
+) => boolean | void | Promise<boolean | void>
+
+/* ============================================================================
+ * Category 2 — Result producers (run at commit, accept / reject / transform)
+ * ========================================================================== */
+
+/** The one canonical update result. */
+export type UpdateResult<T = JsonData> =
+  | true // proceed
+  | void
+  | undefined
+  | false // reject (generic error)
+  | {
+      value?: T // override the committed value
+      error?: string | JsonEditorError // reject with message (a bare string is wrapped)
+      cancel?: true // silent abort — no commit, no error
+    }
+
+/**
+ * `NodeData` carries the CURRENT identity/value; the event-specific field
+ * carries the NEW bit; `newData` is always the resulting document. `rename` and
+ * `move` are first-class events even though both are delete+add under the hood —
+ * they arrive via distinct user interactions and carry distinct deltas.
+ */
+export type UpdateFunctionProps<T = JsonData> = NodeData<T> & { newData: T } & (
+    | { event: 'edit'; newValue: unknown } // value changes (incl. type change)
+    // For `add`, `NodeData` describes the new node's *position* (`path`/`key`);
+    // `value` is unset until commit.
+    | { event: 'add'; newValue: unknown }
+    | { event: 'delete' } // `newData` reflects the removal
+    | { event: 'rename'; newKey: CollectionKey } // `NodeData.key`/`path` = OLD; use `newKey` + `newData`
+    | { event: 'move'; newPath: CollectionKey[] } // `NodeData.path` = source; `newPath` = destination
+  )
+
+/** One `onUpdate` — branch on `event`. Fires for user- and command-driven alike. */
+export type UpdateFunction<T = JsonData> = (
+  props: UpdateFunctionProps<T>
+) => UpdateResult<T> | Promise<UpdateResult<T>>
+
+/** Transform (distinct contract — returns the value, not a result). */
+export type OnChangeFunction<T = JsonData> = (
+  props: NodeData<T> & { newValue: ValueData }
+) => ValueData
+
+/* ============================================================================
+ * Category 3 — Observers (run after, return ignored)
+ * ========================================================================== */
+
+/** After any error condition (Group A codes). */
+export type OnErrorFunction<T = JsonData> = (
+  props: NodeData<T> & { error: JsonEditorError; errorValue: JsonData }
+) => void
+
+/**
+ * The complete interaction-lifecycle stream: value-edit, key-rename and add
+ * sessions (start/confirm/cancel), plus the instant `delete`/`move` (one event
+ * each). `confirmRename` carries `{ oldKey, newKey }`.
+ */
+export type EditEvent<T = JsonData> = NodeData<T> &
+  (
+    | { event: 'startEdit' }
+    | { event: 'confirmEdit' }
+    | { event: 'cancelEdit' }
+    | { event: 'startRename' }
+    | { event: 'confirmRename'; oldKey: CollectionKey; newKey: CollectionKey }
+    | { event: 'cancelRename' }
+    | { event: 'startAdd' }
+    | { event: 'confirmAdd' }
+    | { event: 'cancelAdd' }
+    | { event: 'delete' }
+    | { event: 'move' }
+  )
+
+export type OnEditEventFunction<T = JsonData> = (e: EditEvent<T>) => void
+
+/** On collapse/expand (user click or `editorRef.collapse`). */
+export type OnCollapseFunction<T = JsonData> = (
+  props: NodeData<T> & { collapsed: boolean; includeChildren: boolean }
+) => void
+
+/** After a copy-to-clipboard. Enablement is the `allowClipboard` boolean (Cat 1). */
+export type OnCopyFunction<T = JsonData> = (
+  props: NodeData<T> & {
+    success: boolean
+    stringValue: string
+    type: CopyType
+    error?: JsonEditorError
+  }
+) => void
+
+/* ============================================================================
+ * Category 4 — Imperative commands (the `editorRef` handle)
+ * ========================================================================== */
+
+/**
+ * Strictly binary: did the command run, or was it refused? All descriptive
+ * metadata comes from the observer that fires as a result.
+ */
+export type CommandResult = { success: true } | { success: false; error: JsonEditorError }
+
+// (No `<T>` generic yet — no method references the document type. A later phase
+// adds it if/when typed payloads are threaded through the commands.)
+export interface JsonEditorHandle {
+  // --- Session openers: enter an interactive session (open the input) at a
+  //     node; no value supplied. Sync (just opens). The eventual confirm runs
+  //     the pipeline. Distinct starts, SHARED confirm/cancel (one session open).
+  startEdit(opts: { path: CollectionKey[]; overrideRestrictions?: boolean }): CommandResult
+  startRename(opts: { path: CollectionKey[]; overrideRestrictions?: boolean }): CommandResult
+  startAdd(opts: { path: CollectionKey[]; overrideRestrictions?: boolean }): CommandResult
+  confirm(): Promise<CommandResult> // commit the active session (runs onUpdate)
+  cancel(): void // abort the active session
+
+  // --- Direct ("all-in-one") mutators: do the whole mutation with values
+  //     provided, no UI session. Run the pipeline → async.
+  delete(opts: { path: CollectionKey[]; overrideRestrictions?: boolean }): Promise<CommandResult>
+  edit(opts: {
+    path: CollectionKey[]
+    value: unknown
+    overrideRestrictions?: boolean
+  }): Promise<CommandResult>
+  add(opts: {
+    path: CollectionKey[]
+    value: unknown
+    overrideRestrictions?: boolean
+  }): Promise<CommandResult>
+  rename(opts: {
+    path: CollectionKey[]
+    newKey: CollectionKey
+    overrideRestrictions?: boolean
+  }): Promise<CommandResult>
+  move(opts: {
+    from: CollectionKey[]
+    to: CollectionKey[]
+    overrideRestrictions?: boolean
+  }): Promise<CommandResult>
+
+  // --- Non-mutating
+  collapse(opts: { path: CollectionKey[]; collapsed?: boolean; includeChildren?: boolean }): void
+}

--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -22,7 +22,7 @@
  * §17 phase.
  */
 
-import type { JsonData, CollectionKey, ValueData, CopyType, NodeData } from './types'
+import type { JsonData, CollectionKey, ValueData, NodeData } from './types'
 
 /* ============================================================================
  * Shared building blocks
@@ -157,15 +157,9 @@ export type OnCollapseFunction<T = JsonData> = (
   props: NodeData<T> & { collapsed: boolean; includeChildren: boolean }
 ) => void
 
-/** After a copy-to-clipboard. Enablement is the `allowClipboard` boolean (Cat 1). */
-export type OnCopyFunction<T = JsonData> = (
-  props: NodeData<T> & {
-    success: boolean
-    stringValue: string
-    type: CopyType
-    error?: JsonEditorError
-  }
-) => void
+// `OnCopyFunction` (the `onCopy` observer) graduated to `./types` (it's public,
+// wired by the clipboard split). The remaining staging types here are unused
+// until their phases land.
 
 /* ============================================================================
  * Category 4 — Imperative commands (the `editorRef` handle)

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export {
   type OnCollapseFunction,
   type JerError,
   type DataType,
-  type CopyFunction,
+  type OnCopyFunction,
   type FilterFunction,
   type SearchFilterFunction,
   type TypeFilterFunction,

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export interface JsonEditorProps<T = JsonData> {
   onChange?: OnChangeFunction<T>
   onError?: OnErrorFunction<T>
   showErrorMessages?: boolean
-  enableClipboard?: boolean | CopyFunction
+  allowClipboard?: boolean
   theme?: ThemeInput
   icons?: IconReplacements
   className?: string
@@ -61,6 +61,7 @@ export interface JsonEditorProps<T = JsonData> {
   // Additional events
   onEditEvent?: OnEditEventFunction
   onCollapse?: OnCollapseFunction
+  onCopy?: OnCopyFunction<T>
   // Imperative handle — see `JsonEditorHandle`. Attach with `useRef` and the
   // `editorRef` prop (a plain ref-valued prop, not the `ref` attribute, so the
   // component stays a generic function with full type inference).
@@ -236,15 +237,18 @@ export type SearchFilterInputFunction<T = JsonData> = (
 export type NewKeyOptionsFunction<T = JsonData> = (input: NodeData<T>) => string[] | null | void
 
 export type CopyType = 'path' | 'value'
-export type CopyFunction = (input: {
-  success: boolean
-  errorMessage: string | null
-  key: CollectionKey
-  path: CollectionKey[]
-  value: unknown
-  stringValue: string
-  type: CopyType
-}) => void
+
+// Observer (Cat 3): fires after a copy-to-clipboard. Enablement is the
+// `allowClipboard` boolean (Cat 1). A failed copy carries `error.message`
+// (clipboard failures aren't part of the §17 error-code taxonomy).
+export type OnCopyFunction<T = JsonData> = (
+  props: NodeData<T> & {
+    success: boolean
+    stringValue: string
+    type: CopyType
+    error?: { message: string }
+  }
+) => void
 
 export type CompareFunction = (
   a: [string | number, unknown],
@@ -340,7 +344,8 @@ interface BaseNodeProps {
   showErrorMessages: boolean
   showIconTooltips: boolean
   onMove: InternalMoveFunction
-  enableClipboard: boolean | CopyFunction
+  allowClipboard: boolean
+  onCopy?: OnCopyFunction
   onEditEvent?: OnEditEventFunction
   restrictEditFilter: FilterFunction
   restrictDeleteFilter: FilterFunction

--- a/src/utils/memoNode.ts
+++ b/src/utils/memoNode.ts
@@ -40,7 +40,7 @@
  * (`data`, `parentData`, the `restrict*` filters, display options,
  * `searchText`, `translate`, `customNodeDefinitions`) must likewise be
  * referentially stable for a clean bail-out — standard React guidance; an
- * inline `enableClipboard` etc. reduces the memo's effectiveness without
+ * inline `allowClipboard` etc. reduces the memo's effectiveness without
  * breaking correctness.
  */
 

--- a/test/apiTypes.test.ts
+++ b/test/apiTypes.test.ts
@@ -1,0 +1,125 @@
+/**
+ * §17 API standardisation — Phase 0 compile-check.
+ *
+ * The canonical types in `src/apiTypes.ts` land unused, so nothing in the
+ * `files: ["src/index.ts"]` graph type-checks them. This file is their typecheck
+ * path: ts-jest runs full diagnostics on every `.test.ts`, so the sample typed
+ * values below — especially the exhaustive `switch (props.event)` — fail
+ * compilation (turning `pnpm test` red) if any union stops discriminating or a
+ * field shape drifts from the spec.
+ *
+ * It is NOT a behavioural test — the flows themselves arrive with each later
+ * phase's implementation.
+ */
+
+import type {
+  JsonEditorError,
+  JsonEditorErrorCode,
+  FilterFunction,
+  EventInterceptFunction,
+  UpdateFunction,
+  OnChangeFunction,
+  OnErrorFunction,
+  OnEditEventFunction,
+  OnCollapseFunction,
+  OnCopyFunction,
+  CommandResult,
+  JsonEditorHandle,
+} from '../src/apiTypes'
+import type { JsonData } from '../src/types'
+
+// --- Cat 1: async-capable gates -------------------------------------------
+
+const allow: FilterFunction = (node) => node.path.length > 0
+const allowAsync: FilterFunction = async (node) => node.level > 0
+
+const intercept: EventInterceptFunction = (e) => {
+  // The `event` discriminant narrows; `delete`/`move` are instant.
+  switch (e.event) {
+    case 'startEdit':
+    case 'startRename':
+    case 'startAdd':
+      return // proceed
+    case 'delete':
+    case 'move':
+      return true // take over
+  }
+}
+
+// --- Cat 2: result producer — exhaustive event narrowing ------------------
+
+const onUpdate: UpdateFunction = (props) => {
+  // Each branch must expose exactly its event-specific delta field.
+  switch (props.event) {
+    case 'edit':
+      return { value: props.newValue as JsonData }
+    case 'add':
+      return props.newValue === undefined ? { cancel: true } : true
+    case 'delete':
+      return // proceed (no extra field on this branch)
+    case 'rename':
+      // bare-string error shorthand lives inside the object, not at top level
+      return props.newKey === '' ? { error: 'Empty key' } : { value: props.newData }
+    case 'move':
+      return props.newPath.length === 0 ? false : undefined
+  }
+}
+
+const onChange: OnChangeFunction = (props) => props.newValue
+
+// --- Cat 3: observers ------------------------------------------------------
+
+const onError: OnErrorFunction = (props) => {
+  void props.error.code
+  void props.errorValue
+}
+
+const onEditEvent: OnEditEventFunction = (e) => {
+  // `confirmRename` is the only variant carrying old/new keys.
+  if (e.event === 'confirmRename') void `${String(e.oldKey)}→${String(e.newKey)}`
+}
+
+const onCollapse: OnCollapseFunction = (props) => void (props.collapsed && props.includeChildren)
+
+const onCopy: OnCopyFunction = (props) => void (props.success && props.type)
+
+// --- Shared: error shape ---------------------------------------------------
+
+const code: JsonEditorErrorCode = 'PATH_NOT_FOUND'
+const error: JsonEditorError = { code, message: 'gone' }
+
+// --- Cat 4: imperative handle + binary result discrimination --------------
+
+const describeResult = (r: CommandResult): string =>
+  r.success ? 'ok' : r.error.message // `error` only exists on the failure branch
+
+const handle: JsonEditorHandle = {
+  startEdit: () => ({ success: true }),
+  startRename: () => ({ success: true }),
+  startAdd: () => ({ success: false, error }),
+  confirm: async () => ({ success: true }),
+  cancel: () => undefined,
+  delete: async () => ({ success: true }),
+  edit: async () => ({ success: true }),
+  add: async () => ({ success: true }),
+  rename: async () => ({ success: true }),
+  move: async () => ({ success: true }),
+  collapse: () => undefined,
+}
+
+test('§17 API types compile', () => {
+  // Reference the samples so the file is a real module, not dead code.
+  expect([
+    allow,
+    allowAsync,
+    intercept,
+    onUpdate,
+    onChange,
+    onError,
+    onEditEvent,
+    onCollapse,
+    onCopy,
+    handle,
+    describeResult,
+  ]).toHaveLength(11)
+})

--- a/test/apiTypes.test.ts
+++ b/test/apiTypes.test.ts
@@ -22,11 +22,11 @@ import type {
   OnErrorFunction,
   OnEditEventFunction,
   OnCollapseFunction,
-  OnCopyFunction,
   CommandResult,
   JsonEditorHandle,
 } from '../src/apiTypes'
-import type { JsonData } from '../src/types'
+// `OnCopyFunction` graduated to the public surface with the clipboard split.
+import type { JsonData, OnCopyFunction } from '../src/types'
 
 // --- Cat 1: async-capable gates -------------------------------------------
 

--- a/test/clipboard.test.tsx
+++ b/test/clipboard.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Clipboard split (§17 Phase 1): `allowClipboard` (Cat-1 boolean gate) +
+ * `onCopy` (Cat-3 observer). Replaces the legacy `enableClipboard:
+ * boolean | CopyFunction` overload.
+ *
+ *  - `allowClipboard` (default true) shows/hides the copy button.
+ *  - `onCopy` fires after a copy with `{ success, stringValue, type, ...NodeData }`.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { JsonEditor } from '../src/JsonEditor'
+
+const noop = () => {}
+
+describe('allowClipboard', () => {
+  test('the copy button is shown by default', () => {
+    render(<JsonEditor data={{ x: 'hello' }} setData={noop} showIconTooltips />)
+    expect(screen.getAllByTitle('Copy to clipboard').length).toBeGreaterThan(0)
+  })
+
+  test('allowClipboard={false} hides the copy button', () => {
+    render(
+      <JsonEditor data={{ x: 'hello' }} setData={noop} allowClipboard={false} showIconTooltips />
+    )
+    expect(screen.queryByTitle('Copy to clipboard')).toBeNull()
+  })
+})
+
+describe('onCopy', () => {
+  test('fires after a successful copy with the flat NodeData payload', async () => {
+    const user = userEvent.setup()
+    // Define after setup() so this wins over userEvent's own clipboard stub.
+    const writeText = jest.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+
+    const onCopy = jest.fn()
+    render(
+      <JsonEditor data={{ greeting: 'hello' }} setData={noop} onCopy={onCopy} showIconTooltips />
+    )
+
+    const row = screen.getByText('"hello"').closest('.jer-component') as HTMLElement
+    await user.click(row.querySelector('[title="Copy to clipboard"]') as HTMLElement)
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('hello'))
+    await waitFor(() =>
+      expect(onCopy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          type: 'value',
+          stringValue: 'hello',
+          path: ['greeting'],
+          key: 'greeting',
+        })
+      )
+    )
+  })
+})


### PR DESCRIPTION
Part of the §17 API standardisation umbrella (#289). Carved out of the original Phase 1 (#301).

Splits the dual-purpose `enableClipboard?: boolean | CopyFunction` into two single-purpose props:
- **`allowClipboard?: boolean`** (Cat-1 gate, default `true`) — show/hide the copy button.
- **`onCopy?: OnCopyFunction`** (Cat-3 observer) — runs after a copy, receiving the flat `NodeData` + `{ success, stringValue, type, error? }`. A clipboard-write failure is reported as `error: { message }` (clipboard failures aren't part of the §17 error-code taxonomy).

`CopyFunction` is retired. `OnCopyFunction` graduates from `apiTypes.ts` staging into the public `types.ts` + `index.ts`.

## Why this is its own PR
The original Phase 1 (#301) bundled the clipboard split together with the `onEventIntercept` mechanism. We're **parking `onEventIntercept`** for a design rethink — it adds notable complexity and bundle weight, and the confirm-gate is undercut by Tab being able to commit-and-navigate (which would need yet another prop to close). The clipboard split is independent, finished, and uncontroversial, so it proceeds here; the rest of the §17 phases stack on this branch. The full intercept work is preserved on `feat/v2.0-api-phase-1` / #301 (parked draft) to revisit later. `InterceptableEvent` / `EventInterceptFunction` stay in `apiTypes.ts` staging in the meantime.

## Tests & docs
- `test/clipboard.test.tsx` — `allowClipboard` toggle + `onCopy` payload.
- README props row + Copy Function section + type list; migration-guide §8; demo migrated to `allowClipboard` + `onCopy` (frozen `/v1` demo untouched).

## Verification
`pnpm compile` (tsc + ts-prune) clean · `pnpm lint` clean · `pnpm test` 267 passed / 14 suites · demo `tsc` clean · `pnpm build` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)