### PR TITLE
§17 Phase 3: Category 3 observers — onEditEvent lifecycle stream + flat NodeData (#298)

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ The input is the standard [node data](#filter-functions) (`key`, `path`, `value`
 
 ### OnError Function
 
-Normally, the component will display simple error messages whenever an error condition is detected (e.g. invalid JSON input, duplicate keys, or custom errors returned by the [`onUpdate` function)](#update-functions)). However, you can provide your own `onError` callback in order to implement your own error UI, or run additional side effects. (In the former case, you'd probably want to disable the `showErrorMessages` prop, too.) It receives the standard [node data](#filter-functions) (`key`, `path`, `value`, `fullData`, etc.) with the following additional fields spread on top:
+Normally, the component will display simple error messages whenever an error condition is detected (e.g. invalid JSON input, duplicate keys, or custom errors returned by the [`onUpdate` function](#update-functions)). However, you can provide your own `onError` callback in order to implement your own error UI, or run additional side effects. (In the former case, you'd probably want to disable the `showErrorMessages` prop, too.) It receives the standard [node data](#filter-functions) (`key`, `path`, `value`, `fullData`, etc.) with the following additional fields spread on top:
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -422,21 +422,15 @@ The input is the standard [node data](#filter-functions) (`key`, `path`, `value`
 
 ### OnError Function
 
-Normally, the component will display simple error messages whenever an error condition is detected (e.g. invalid JSON input, duplicate keys, or custom errors returned by the [`onUpdate` functions)](#update-functions)). However, you can provide your own `onError` callback in order to implement your own error UI, or run additional side effects. (In the former case, you'd probably want to disable the `showErrorMessages` prop, too.) The input is similar to the other callbacks:
+Normally, the component will display simple error messages whenever an error condition is detected (e.g. invalid JSON input, duplicate keys, or custom errors returned by the [`onUpdate` function)](#update-functions)). However, you can provide your own `onError` callback in order to implement your own error UI, or run additional side effects. (In the former case, you'd probably want to disable the `showErrorMessages` prop, too.) It receives the standard [node data](#filter-functions) (`key`, `path`, `value`, `fullData`, etc.) with the following additional fields spread on top:
 
 ```js
 {
-    currentData,  // data state before update 
-    currentValue, // the current value of the property being updated
+    // ...standard node data (key, path, value, fullData, ...)
     errorValue,   // the erroneous value that failed to update the property
-    name,         // name of the property being updated
-    path,         // full path to the property being updated,
-                  //   as an array of property keys
-                  //   (e.g. [ "user", "friends", 1, "name" ] )
-                  //   (equivalent to "user.friends[1].name"),
-    error: {
-      code,       // one of 'UPDATE_ERROR' | 'DELETE_ERROR' |
-                  //   'ADD_ERROR' | 'INVALID_JSON' | 'KEY_EXISTS'
+    error: {      // a JsonEditorError
+      code,       // one of 'UPDATE_ERROR' | 'DELETE_ERROR' | 'ADD_ERROR'
+                  //   | 'INVALID_JSON' | 'KEY_EXISTS'
       message     // the (localised) error message that would be displayed
     }
 }
@@ -455,7 +449,8 @@ The `onCopy` callback runs whenever an item is **copied** to the clipboard. It r
     stringValue  // A nicely stringified version of the copied value
                  // (i.e. what the clipboard actually receives)
     success      // true/false -- whether the clipboard copy action actually succeeded
-    error        // `{ message }` with the failure detail when `success === false`
+    error        // a JsonEditorError `{ code: 'CLIPBOARD_ERROR', message }`
+                 //   present only when `success === false`
 }
 ```
 
@@ -1245,27 +1240,39 @@ You can interact with the component externally, with event callbacks and trigger
 
 Pass in a function to the props `onEditEvent` and `onCollapse` if you want your app to be able to respond to these events.
 
-The `onEditEvent` callback is executed whenever the user starts or stops editing a node, and has the following signature:
+The `onEditEvent` callback streams the complete **interaction lifecycle** — start/confirm/cancel for value-edit, key-rename and add sessions, plus the instant `delete`/`move`. It receives the standard [node data](#filter-functions) (`key`, `path`, `value`, `fullData`, …) with an `event` discriminant spread on top:
 
 ```ts
-type OnEditEventFunction = 
-  (path: (CollectionKey | null)[] | null, isKey: boolean) => void
+type EditEvent =
+  // value edit
+  | { event: 'startEdit' } | { event: 'confirmEdit' } | { event: 'cancelEdit' }
+  // key rename ('confirmRename' also carries oldKey + newKey)
+  | { event: 'startRename' }
+  | { event: 'confirmRename'; oldKey: CollectionKey; newKey: CollectionKey }
+  | { event: 'cancelRename' }
+  // add
+  | { event: 'startAdd' } | { event: 'confirmAdd' } | { event: 'cancelAdd' }
+  // instant (no session)
+  | { event: 'delete' } | { event: 'move' }
+// ...each spread onto the node's NodeData
+type OnEditEventFunction = (e: EditEvent) => void
 ```
 
-The `path` will be an array representing the path components when starting to edit, and `null` when ending the edit. The `isKey` indicates whether the edit is for the property `key` rather than `value`.
+A session opens with a `start*` and terminates with **exactly one** of `confirm*` (the change was committed) or `cancel*` (the session closed *without* committing — an explicit cancel, a no-op confirm where nothing changed, or a change your `onUpdate` rejected/aborted). `delete` and `move` fire a single event on commit.
 
-> [!NOTE] 
-> After clicking the "Add key" button, the `path` in the `onEditEvent` callback will end with a `null` value, indicating that the final path where this key will end up is not yet known.
+A few things worth knowing:
+- **Add events describe the parent collection** (the node you're adding *into*); `confirmAdd` is where the add lands.
+- **Array adds are instant** — they emit only `confirmAdd` (no `startAdd`/`cancelAdd`, since there's no key-entry step).
+- A type change mid-edit is itself a commit, so it emits `confirmEdit` while the edit session stays open — one session can emit multiple `confirmEdit`s.
 
-The `onCollapse` callback is executed when user opens or collapses a node, and has the following signature:
+The `onCollapse` callback is executed when the user opens or collapses a node (or you drive it via `editorRef.collapse`). It receives the node's [node data](#filter-functions) with the collapse flags spread on top:
 
 ```ts
 type OnCollapseFunction = (
-  {
-    path: CollectionKey[],
-    collapsed: boolean, // closing = true, opening = false
-    includeChildren: boolean // if was clicked with Modifier key to
-                             // open/close all descendants as well
+  props: NodeData & {
+    collapsed: boolean // closing = true, opening = false
+    includeChildren: boolean // if opened/closed with the Modifier key to
+                             // affect all descendants as well
   }
 ) => void
 ```
@@ -1375,7 +1382,7 @@ A few helper functions, components and types that might be useful in your own im
 - `ThemeInput`: input type for the `theme` prop
 - `JsonEditorProps<T>`: all input props for the Json Editor component. Generic on the data type — see [Typed data](#typed-data).
 - `JsonData`: main `data` object -- any valid JSON structure. Used as the default for `T`.
-- [`UpdateFunction`](#update-functions), [`UpdateResult`](#update-functions), [`OnChangeFunction`](#onchange-function), [`OnErrorFunction`](#onerror-function) [`FilterFunction`](#filter-functions), [`OnCopyFunction`](#copy-function), [`SearchFilterFunction`](#searchfiltering), [`OnEditEventFunction`](#event-callbacks), [`OnCollapseFunction`](#event-callbacks), [`CompareFunction`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort),[`TypeFilterFunction`](#filter-functions), [`NewKeyOptionsFunction`](#new-key-restrictions--default-values), [`DefaultValueFunction`](#new-key-restrictions--default-values)
+- [`UpdateFunction`](#update-functions), [`UpdateResult`](#update-functions), [`OnChangeFunction`](#onchange-function), [`OnErrorFunction`](#onerror-function) [`FilterFunction`](#filter-functions), [`OnCopyFunction`](#copy-function), [`SearchFilterFunction`](#searchfiltering), [`OnEditEventFunction`](#event-callbacks) / [`EditEvent`](#event-callbacks), [`OnCollapseFunction`](#event-callbacks), [`CompareFunction`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort),[`TypeFilterFunction`](#filter-functions), [`NewKeyOptionsFunction`](#new-key-restrictions--default-values), [`DefaultValueFunction`](#new-key-restrictions--default-values)
 - `JsonEditorError` / `JsonEditorErrorCode`: the canonical error shape (`{ code, message }`) reported to [`onError`](#onerror-function) and accepted in an [`UpdateFunction`](#update-functions) `{ error }` return
 - [`CustomNodeDefinition`](#custom-nodes), [`CustomTextDefinitions`](#custom-text), [`CustomTextFunction`](#custom-text), [`JsonEditorHandle`](#imperative-handle-editorref), [`JsonViewerHandle`](#imperative-handle-editorref), [`StartEditOptions`](#imperative-handle-editorref): input types of the respective props
 - `TranslateFunction`: function that takes a [localisation](#localisation) key and returns a translated string

--- a/V2-roadmap.md
+++ b/V2-roadmap.md
@@ -223,6 +223,7 @@ type JsonEditorErrorCode =
   | 'DELETE_ERROR'    // a delete was rejected
   | 'KEY_EXISTS'      // a new/renamed key collides with an existing sibling
   | 'INVALID_JSON'    // raw JSON typed into the editor failed to parse
+  | 'CLIPBOARD_ERROR' // a copy-to-clipboard write failed (onCopy)
   // Group B — imperative command flow (Category 4)
   | 'PATH_NOT_FOUND'  // a command targeted a path that doesn't exist in the current data
   | 'RESTRICTED'      // a command's action is blocked by an allow* filter (no overrideRestrictions set)

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -660,7 +660,7 @@ function App() {
                       : undefined
                   }
                   // collapseClickZones={['property', 'header']}
-                  onEditEvent={(path) => setIsEditing(path !== null)}
+                  onEditEvent={(e) => setIsEditing(e.event.startsWith('start'))}
                   onCollapse={(input) => {
                     // Showcase the onCollapse callback — only while the External
                     // Control panel is on screen (fires for both handle-driven

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -18,7 +18,8 @@ If you only have a few minutes, these are the changes most likely to affect exis
 | `externalTriggers` prop replaced by the `editorRef` imperative handle | Use a `useRef<JsonEditorHandle>` and call `editorRef.current.collapse/startEdit/cancelEdit/confirmEdit` — see §7 |
 | `enableClipboard` split into `allowClipboard` (boolean) + `onCopy` (callback); `CopyFunction` → `OnCopyFunction` | Rename the boolean to `allowClipboard`; move any copy callback to `onCopy` (`errorMessage` → `error.message`) — see §8 |
 | `onEdit` / `onAdd` / `onDelete` merged into one `onUpdate`; return shape unified | Use a single `onUpdate` and `switch (props.event)`; replace tuple / bare-string returns with `{ value }` / `{ error }` (and `null` to silently cancel) — see §9 |
-| Callback payloads are now flat `NodeData` (`currentData`→`fullData`, `currentValue`→`value`, `name`→`key`); `JerError` → `JsonEditorError` | Update field names in `onUpdate` / `onChange` / `onError`; rename the error type — see §9 |
+| Callback payloads are now flat `NodeData` (`currentData`→`fullData`, `currentValue`→`value`, `name`→`key`); `JerError` → `JsonEditorError` | Update field names in `onUpdate` / `onChange` / `onError`; rename the error type — see §9, §10 |
+| `onEditEvent` is now a lifecycle stream `(e) => …` (was `(path, isKey) => …`); `onError` / `onCollapse` use flat `NodeData`; `onCopy.error` is a `JsonEditorError` | `switch (e.event)` over start/confirm/cancel + delete/move; update the flat payload fields — see §10 |
 
 ---
 
@@ -399,12 +400,65 @@ Every callback now receives the standard flat [`NodeData`](README.md#filter-func
 
 ### `JerError` → `JsonEditorError`
 
-The error type reported to `onError` (and accepted in an `onUpdate` `{ error }` return) is renamed; its shape (`{ code, message }`) is unchanged, and the `code` union gains some forward-looking members. `onError`'s own payload fields are otherwise unchanged in this release.
+The error type reported to `onError` (and accepted in an `onUpdate` `{ error }` return) is renamed; its shape (`{ code, message }`) is unchanged, and the `code` union gains some forward-looking members. (`onError`'s own payload also moves to flat `NodeData` — see §10.)
 
 ```diff
 - import { type JerError } from 'json-edit-react'
 + import { type JsonEditorError } from 'json-edit-react'
 ```
+
+---
+
+## 10. Observers reshaped: `onEditEvent` lifecycle stream; flat `onError` / `onCollapse`; `onCopy` error
+
+The observer callbacks move onto the same flat `NodeData` payload as the rest of the API, and `onEditEvent` becomes a full lifecycle stream.
+
+### `onEditEvent` — from `(path, isKey)` to a discriminated event stream
+
+```diff
+- onEditEvent={(path, isKey) => {
+-   if (path === null) /* ended editing */
+-   else if (isKey)   /* started editing a key */
+-   else              /* started editing a value */
+- }}
++ onEditEvent={(e) => {
++   switch (e.event) {
++     case 'startEdit': case 'startRename': case 'startAdd': /* a session opened */ break
++     case 'confirmEdit': case 'confirmRename': case 'confirmAdd': /* committed */ break
++     case 'cancelEdit': case 'cancelRename': case 'cancelAdd': /* closed, no change */ break
++     case 'delete': case 'move': /* instant */ break
++   }
++   // e is the node's NodeData + the `event`; 'confirmRename' also has oldKey/newKey
++ }}
+```
+
+It now fires for the **complete** lifecycle (start → confirm/cancel) of value-edit, key-rename and add sessions, plus the instant `delete`/`move` — not just edit start/stop. This absorbs the role a dedicated `onRenameProperty` would have played (a rename surfaces as `startRename`/`confirmRename`/`cancelRename`). A no-op confirm (closing with no change) and a rejected/aborted change both report as `cancel*`.
+
+### `onError` and `onCollapse` — flat `NodeData`
+
+Both now receive the standard flat node data instead of a bespoke object:
+
+```diff
+  // onError
+- onError={({ currentData, currentValue, name, path, error, errorValue }) => ...}
++ onError={({ fullData, value, key, path, error, errorValue }) => ...}
+
+  // onCollapse — the `collapsed` / `includeChildren` flags are unchanged; the
+  // rest of the payload is now full NodeData (so `key`, `value`, `fullData`, … too)
+  onCollapse={({ path, collapsed, includeChildren }) => ...} // still works
+```
+
+(`currentData`→`fullData`, `currentValue`→`value`, `name`→`key`, matching §9.) `CollapseState` — the `editorRef.collapse` command **input** — is unchanged.
+
+### `onCopy` — `error` is now a `JsonEditorError`
+
+```diff
+- onCopy={({ success, error }) => { if (!success) console.error(error?.message) }}
++ onCopy={({ success, error }) => { if (!success) console.error(error?.message) }}
+  // error is now `{ code: 'CLIPBOARD_ERROR', message }` instead of `{ message }`
+```
+
+`error.message` still works; the addition is the `code` field (`'CLIPBOARD_ERROR'`).
 
 ---
 

--- a/src/ButtonPanels.tsx
+++ b/src/ButtonPanels.tsx
@@ -13,6 +13,7 @@ import {
   type OnCopyFunction,
   JsonData,
   OnEditEventFunction,
+  type EditEvent,
 } from './types'
 import { getModifier } from './utils/keyboard'
 
@@ -75,12 +76,14 @@ export const EditButtons: React.FC<EditButtonProps> = ({
 
   const hasKeyOptionsList = Array.isArray(addingKeyState)
 
+  // Add events describe the parent collection (this node). `startAdd` fires when
+  // the key-entry UI opens; `confirmAdd` comes from the commit (CollectionNode),
+  // `cancelAdd` from the cancel handlers below.
+  const emitAddEvent = (event: 'startAdd' | 'cancelAdd') =>
+    onEditEvent?.({ ...nodeData, event } as EditEvent)
+
   const updateAddingState = (active: boolean) => {
-    // Add 'null' to the path to indicate that the actual path of where the new
-    // key will go is not yet known.
-    // Also, "active" matches the second "isKey" parameter here, even though it
-    // describes a different thing.
-    if (onEditEvent) onEditEvent(active ? [...path, null] : null, active)
+    if (active) emitAddEvent('startAdd')
 
     if (!active) {
       setAddingKeyState(false)
@@ -111,6 +114,7 @@ export const EditButtons: React.FC<EditButtonProps> = ({
       },
       cancel: () => {
         updateAddingState(false)
+        emitAddEvent('cancelAdd')
         setNewKey(NEW_KEY_PROMPT)
       },
     })
@@ -139,7 +143,7 @@ export const EditButtons: React.FC<EditButtonProps> = ({
           success: false,
           stringValue,
           type: copyType,
-          error: { message: "Can't access clipboard API" },
+          error: { code: 'CLIPBOARD_ERROR', message: "Can't access clipboard API" },
         })
         return
       }
@@ -156,7 +160,9 @@ export const EditButtons: React.FC<EditButtonProps> = ({
             success,
             stringValue,
             type: copyType,
-            error: success ? undefined : { message: errorMessage ?? 'Copy failed' },
+            error: success
+              ? undefined
+              : { code: 'CLIPBOARD_ERROR', message: errorMessage ?? 'Copy failed' },
           })
         })
     }
@@ -225,7 +231,10 @@ export const EditButtons: React.FC<EditButtonProps> = ({
                 autoFocus
                 onKeyDown={(e: React.KeyboardEvent) => {
                   handleKeyboard(e, {
-                    cancel: () => updateAddingState(false),
+                    cancel: () => {
+                      updateAddingState(false)
+                      emitAddEvent('cancelAdd')
+                    },
                   })
                 }}
               >
@@ -264,6 +273,7 @@ export const EditButtons: React.FC<EditButtonProps> = ({
             }}
             onCancel={() => {
               updateAddingState(false)
+              emitAddEvent('cancelAdd')
             }}
             nodeData={nodeData}
             editConfirmRef={editConfirmRef}

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -7,6 +7,7 @@ import {
   type NodeData,
   type CollectionData,
   type ValueData,
+  type EditEvent,
 } from './types'
 import { Icon } from './Icons'
 import { filterNode } from './utils/filter'
@@ -30,7 +31,7 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
   const { getStyles } = useTheme()
   // Actions + imperative reads from the (stable) store — no subscription, so
   // editing transitions elsewhere don't re-render this node.
-  const { startEdit, cancelEdit, setPreviousValue, areChildrenBeingEdited, getSnapshot } =
+  const { startEdit, cancelEdit, closeEdit, setPreviousValue, areChildrenBeingEdited, getSnapshot } =
     useEditingStore()
   const { setCollapseState } = useCollapse()
   const {
@@ -245,6 +246,13 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
     })
   }
 
+  // Fire an `onEditEvent` for this collection's edit/add/delete lifecycle.
+  // `nodeData` is read live (handlers re-created each render). Add events
+  // describe the parent collection (this node).
+  const emitEditEvent = (
+    event: Extract<EditEvent['event'], 'confirmEdit' | 'cancelEdit' | 'confirmAdd' | 'delete'>
+  ) => onEditEvent?.({ ...nodeData, event } as EditEvent)
+
   const handleCollapse = (e: React.MouseEvent) => {
     e.stopPropagation()
     const modifier = getModifier(e)
@@ -255,7 +263,9 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
     }
     if (!areChildrenBeingEdited(path)) {
       hasBeenOpened.current = true
-      if (onCollapse) onCollapse({ path, collapsed: !collapsed, includeChildren: false })
+      // Flat NodeData (§17): explicit `collapsed` (post-toggle) must come after
+      // `...nodeData` (whose `collapsed` is the pre-toggle value).
+      if (onCollapse) onCollapse({ ...nodeData, collapsed: !collapsed, includeChildren: false })
       animateCollapse(!collapsed)
     }
   }
@@ -269,7 +279,7 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
     const textToParse = editBufferValue ?? jsonStringify(data)
     try {
       const value = jsonParse(textToParse)
-      cancelEdit()
+      closeEdit()
       setPreviousValue(null)
       setError(null)
       // No-op confirm: bail without committing. When the buffer was never
@@ -277,13 +287,21 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
       // rather than serializing `data` a second time.
       const currentDataString = stringifiedValue === null ? textToParse : jsonStringify(data)
       clearEditBuffer()
-      if (jsonStringify(value) === currentDataString) return
-      onEdit(value, path).then((error) => {
-        if (error) {
-          onError({ code: 'UPDATE_ERROR', message: error }, value as CollectionData)
-        }
+      // No-op confirm (unchanged JSON) reports as a cancel (closed without change).
+      if (jsonStringify(value) === currentDataString) {
+        emitEditEvent('cancelEdit')
+        return
+      }
+      onEdit(value, path).then((result) => {
+        if (result === false) emitEditEvent('cancelEdit')
+        else if (result) {
+          onError({ code: 'UPDATE_ERROR', message: result }, value as CollectionData)
+          emitEditEvent('cancelEdit')
+        } else emitEditEvent('confirmEdit')
       })
     } catch {
+      // Parse failure leaves the edit session OPEN (user can fix the JSON), so
+      // no terminal event — only the error.
       onError(
         { code: 'INVALID_JSON', message: translate('ERROR_INVALID_JSON', nodeData) },
         textToParse
@@ -299,15 +317,17 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
     if (collectionType === 'array') {
       const index = insertAtTop.array ? 0 : (data as unknown[]).length
       const options = insertAtTop.array ? { insert: true } : {}
-      onAdd(newValue, [...path, index], options).then((error) => {
-        if (error) onError({ code: 'ADD_ERROR', message: error }, newValue as CollectionData)
+      onAdd(newValue, [...path, index], options).then((result) => {
+        if (result) onError({ code: 'ADD_ERROR', message: result }, newValue as CollectionData)
+        else if (result === undefined) emitEditEvent('confirmAdd')
       })
     } else if (key in data) {
       onError({ code: 'KEY_EXISTS', message: translate('ERROR_KEY_EXISTS', nodeData) }, key)
     } else {
       const options = insertAtTop.object ? { insertBefore: 0 } : {}
-      onAdd(newValue, [...path, key], options).then((error) => {
-        if (error) onError({ code: 'ADD_ERROR', message: error }, newValue as CollectionData)
+      onAdd(newValue, [...path, key], options).then((result) => {
+        if (result) onError({ code: 'ADD_ERROR', message: result }, newValue as CollectionData)
+        else if (result === undefined) emitEditEvent('confirmAdd')
       })
     }
   }
@@ -315,10 +335,9 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
   const handleDelete =
     path.length > 0
       ? () => {
-          onDelete(data, path).then((error) => {
-            if (error) {
-              onError({ code: 'DELETE_ERROR', message: error }, data)
-            }
+          onDelete(data, path).then((result) => {
+            if (result) onError({ code: 'DELETE_ERROR', message: result }, data)
+            else if (result === undefined) emitEditEvent('delete')
           })
         }
       : undefined

--- a/src/JsonEditor.tsx
+++ b/src/JsonEditor.tsx
@@ -23,6 +23,9 @@ import {
   type CollectionKey,
   type UpdateFunctionProps,
   type SortFunction,
+  type BuildNodeDataFromPath,
+  type BuildNodeDataFromPathRef,
+  type EditEvent,
   type JsonData,
   type KeyboardControls,
   ValueData,
@@ -84,9 +87,12 @@ const EMPTY_CUSTOM_TEXT: NonNullable<JsonEditorProps<JsonData>['customText']> = 
 const EMPTY_KEYBOARD_CONTROLS: NonNullable<JsonEditorProps<JsonData>['keyboardControls']> = {}
 const EMPTY_CUSTOM_BUTTONS: NonNullable<JsonEditorProps<JsonData>['customButtons']> = []
 
-const Editor: React.FC<JsonEditorProps<JsonData>> = ({
+const Editor: React.FC<
+  JsonEditorProps<JsonData> & { buildNodeDataFromPathRef: BuildNodeDataFromPathRef }
+> = ({
   data,
   setData,
+  buildNodeDataFromPathRef,
   rootName = 'root',
   onUpdate = NOOP,
   onChange,
@@ -252,7 +258,10 @@ const Editor: React.FC<JsonEditorProps<JsonData>> = ({
         value,
         'update'
       )
-      if (currentValue === newValue) return
+      // No-op confirm (value unchanged): signal the caller to treat it as a
+      // cancel (the `false` sentinel — same channel as a silent `null` cancel),
+      // so the edit session reports `cancelEdit` rather than `confirmEdit`.
+      if (currentValue === newValue) return false
 
       return await handleEdit({
         ...buildNodeData(dataRef.current, path, rootNameRef.current, sortRef.current),
@@ -382,14 +391,27 @@ const Editor: React.FC<JsonEditorProps<JsonData>> = ({
         insertOptions as UpdateOptions
       )
 
-      return await handleEdit({
-        ...buildNodeData(dataRef.current, sourcePath, rootNameRef.current, sortRef.current),
+      // Source node's NodeData (pre-move tree — `dataRef` still holds it until
+      // the commit re-renders). Used for both the `onUpdate` move payload and
+      // the `onEditEvent` move observer.
+      const sourceNodeData = buildNodeData(
+        dataRef.current,
+        sourcePath,
+        rootNameRef.current,
+        sortRef.current
+      )
+      const result = await handleEdit({
+        ...sourceNodeData,
         newData: addedData,
         event: 'move',
         newPath: destPath,
       })
+      // Observer (Cat 3): a committed move fires `onEditEvent` with the source
+      // node. (Fired here, not at the drop site, which only has the target.)
+      if (result === undefined) onEditEventStable?.({ ...sourceNodeData, event: 'move' } as EditEvent)
+      return result
     },
-    [handleEdit]
+    [handleEdit, onEditEventStable]
   )
 
   const restrictEditFilter = useMemo(() => getFilterFunction(restrictEdit), [restrictEdit])
@@ -459,6 +481,16 @@ const Editor: React.FC<JsonEditorProps<JsonData>> = ({
   // Late-assigned (see the ref declaration above): the stable update handlers
   // read the live comparator from here when building a node's `NodeData`.
   sortRef.current = sort
+
+  // Populate the bridge the editing/collapse providers read at event time to
+  // build a node's flat `NodeData` from just a path (they're ancestors of this
+  // component, so they can't reach `getLatestData`/`sort` directly). Stable over
+  // `getLatestData`; reads `rootName`/`sort` from refs so the identity holds.
+  const buildNodeDataFromPath = useCallback<BuildNodeDataFromPath>(
+    (path) => buildNodeData(getLatestData(), path, rootNameRef.current, sortRef.current),
+    [getLatestData]
+  )
+  buildNodeDataFromPathRef.current = buildNodeDataFromPath
 
   // Imperative handle (`editorRef` prop). The methods call the LIVE setters /
   // read the LIVE tree at call time, never a frozen render closure (per
@@ -585,6 +617,11 @@ const Editor: React.FC<JsonEditorProps<JsonData>> = ({
 export function JsonEditor<T = JsonData>(props: JsonEditorProps<T>): React.ReactElement | null {
   const [docRoot, setDocRoot] = useState<HTMLElement>()
 
+  // Shared bridge: `Editor` (which owns the live data) populates this each
+  // render; the editing/collapse providers (its ancestors) read it at event
+  // time to build flat `NodeData` for the observer events they fire.
+  const buildNodeDataFromPathRef = useRef<BuildNodeDataFromPath | undefined>(undefined)
+
   // We want access to the global document.documentElement object, but can't
   // access it directly when used with SSR. So we set it inside a `useEffect`,
   // which won't run server-side (it'll just be undefined) until client
@@ -602,8 +639,12 @@ export function JsonEditor<T = JsonData>(props: JsonEditorProps<T>): React.React
 
   return (
     <ThemeProvider theme={innerProps.theme ?? defaultTheme} icons={innerProps.icons} docRoot={docRoot}>
-      <TreeStateProvider onEditEvent={innerProps.onEditEvent} onCollapse={innerProps.onCollapse}>
-        <Editor {...innerProps} />
+      <TreeStateProvider
+        onEditEvent={innerProps.onEditEvent}
+        onCollapse={innerProps.onCollapse}
+        buildNodeDataFromPathRef={buildNodeDataFromPathRef}
+      >
+        <Editor {...innerProps} buildNodeDataFromPathRef={buildNodeDataFromPathRef} />
       </TreeStateProvider>
     </ThemeProvider>
   )

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -243,8 +243,17 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
     const customNode = customNodeDefinitions.find((customNode) => customNode.name === type)
     if (customNode) {
       onEdit(customNode.defaultValue, path).then((result) => {
-        if (result) revertToData()
-        else emitEditEvent('confirmEdit')
+        if (result === false) {
+          revertToData()
+          emitEditEvent('cancelEdit')
+        } else if (result) {
+          onError(
+            { code: 'UPDATE_ERROR', message: result },
+            customNode.defaultValue as JsonData
+          )
+          revertToData()
+          emitEditEvent('cancelEdit')
+        } else emitEditEvent('confirmEdit')
       })
       setDataType(type)
       setEnumType(null)
@@ -341,8 +350,14 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
     })
   }
 
-  const handleCancel = () => {
-    cancelEdit()
+  // Per-node UI/data cleanup for any session-ending path that isn't a
+  // confirm: explicit cancel (Esc/✗), node switch (another node steals the
+  // edit), or external cancel (search reset, `editorRef.cancelEdit`).
+  // Registered as the store's `cancelOp` so the store invokes it uniformly;
+  // it does NOT call back into the store. Both steps are idempotent so the
+  // function is safe to run twice in the user-cancel path (once from
+  // `handleCancel` directly, once from the store invoking `cancelOp`).
+  const revertSession = () => {
     const previousValue = getSnapshot().previousValue
     if (previousValue !== null) {
       onEdit(previousValue, path)
@@ -354,6 +369,17 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
     }
     revertToData()
     setPreviousValue(null)
+  }
+
+  const handleCancel = () => {
+    // Revert locally then drive the store cancel. Driving the store also runs
+    // `cancelOp` (= `revertSession`) for the canonical external-cancel path,
+    // so this looks redundant — but `revertSession` is idempotent, and we
+    // still want the local revert to happen on entry paths that don't
+    // register a `cancelOp` (Tab-arrival, redirect from a filtered node),
+    // where the store has no op to invoke.
+    revertSession()
+    cancelEdit()
   }
 
   const handleDelete = () => {
@@ -379,7 +405,7 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
     setValue: updateValue,
     isEditing,
     canEdit,
-    setIsEditing: canEdit ? () => startEdit(path) : NOOP,
+    setIsEditing: canEdit ? () => startEdit(path, { cancelOp: revertSession }) : NOOP,
     handleEdit,
     handleCancel,
     path,
@@ -443,7 +469,7 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
         handleKeyboard(e, { stringConfirm: handleEdit, cancel: handleCancel })
       }
       isEditing={isEditing}
-      setIsEditing={() => startEdit(path)}
+      setIsEditing={() => startEdit(path, { cancelOp: revertSession })}
       getStyles={getStyles}
       originalNode={passOriginalNode ? getInputComponent(data, inputProps) : undefined}
       originalNodeKey={
@@ -513,7 +539,7 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
                         // previously-abandoned edit session so a cancel
                         // doesn't unexpectedly revert to a stale value.
                         setPreviousValue(null)
-                        startEdit(path, { cancelOp: handleCancel })
+                        startEdit(path, { cancelOp: revertSession })
                       }
                     : undefined
                 }

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -17,6 +17,7 @@ import {
   type ValueData,
   type JsonData,
   type EnumDefinition,
+  type EditEvent,
 } from './types'
 import { useTheme, useEditingStore, useCollapse } from './contexts'
 import { type CustomNodeData } from './CustomNode'
@@ -35,6 +36,7 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
     onDelete,
     onChange,
     onMove,
+    onEditEvent,
     allowClipboard,
     onCopy,
     canDragOnto,
@@ -64,8 +66,15 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
   // it's read from the snapshot at use-time rather than subscribed to. The only
   // editing state that drives this node's render (`isEditing`) comes from
   // `useCommon`'s per-node selector.
-  const { startEdit, cancelEdit, recordPreviousEdit, setTabDirection, setPreviousValue, getSnapshot } =
-    useEditingStore()
+  const {
+    startEdit,
+    cancelEdit,
+    closeEdit,
+    recordPreviousEdit,
+    setTabDirection,
+    setPreviousValue,
+    getSnapshot,
+  } = useEditingStore()
   const { setCollapseState } = useCollapse()
   const [value, setValue] = useState<typeof data | CollectionData>(
     // Bad things happen when you put a function into useState
@@ -212,6 +221,11 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
 
   if (!isVisible) return null
 
+  // Fire an `onEditEvent` for this node's value-edit session. `nodeData` is read
+  // live (these handlers are re-created each render), so no ref needed.
+  const emitEditEvent = (event: Extract<EditEvent['event'], 'startEdit' | 'confirmEdit' | 'cancelEdit' | 'delete'>) =>
+    onEditEvent?.({ ...nodeData, event } as EditEvent)
+
   const handleChangeDataType = (type: DataType) => {
     // Contract #3: user-action clears broadcast. See CollapseProvider top-of-file doc.
     setCollapseState(null)
@@ -222,11 +236,14 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
     if (getSnapshot().previousValue === null) setPreviousValue(value as JsonData)
     const customNode = customNodeDefinitions.find((customNode) => customNode.name === type)
     if (customNode) {
-      onEdit(customNode.defaultValue, path)
+      onEdit(customNode.defaultValue, path).then((result) => {
+        if (result) revertToData()
+        else emitEditEvent('confirmEdit')
+      })
       setDataType(type)
       setEnumType(null)
       // Custom nodes will be instantiated expanded and NOT editing
-      cancelEdit()
+      closeEdit()
       setCollapseState({ path, collapsed: false, includeChildren: false })
       return
     }
@@ -239,16 +256,19 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
       if (typeof value !== 'string' || !enumType.values.includes(value)) {
         const attempted = enumType.values[0]
         onEdit(attempted, path).then((result) => {
-          if (result === false) revertToData()
-          else if (result) {
+          if (result === false) {
+            revertToData()
+            emitEditEvent('cancelEdit')
+          } else if (result) {
             // `attempted` rather than `newValue` — `newValue` is declared
             // further down in this function and is never reached on this
             // branch (we return at `setEnumType` below), so referencing it
             // from this callback would throw a TDZ ReferenceError.
             onError({ code: 'UPDATE_ERROR', message: result }, attempted as JsonData)
-            cancelEdit()
+            closeEdit()
             revertToData()
-          }
+            emitEditEvent('cancelEdit')
+          } else emitEditEvent('confirmEdit')
         })
       }
       setEnumType(enumType)
@@ -263,19 +283,25 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
       // that won't match the custom node condition any more
       customNodeData?.CustomNode ? translate('DEFAULT_STRING', nodeData) : undefined
     )
-    if (!['string', 'number', 'boolean'].includes(type)) cancelEdit()
+    if (!['string', 'number', 'boolean'].includes(type)) closeEdit()
     onEdit(newValue, path).then((result) => {
-      if (result === false) revertToData()
-      else if (result) {
-        onError({ code: 'UPDATE_ERROR', message: result }, newValue as JsonData)
-        cancelEdit()
+      if (result === false) {
         revertToData()
-      } else setEnumType(null)
+        emitEditEvent('cancelEdit')
+      } else if (result) {
+        onError({ code: 'UPDATE_ERROR', message: result }, newValue as JsonData)
+        closeEdit()
+        revertToData()
+        emitEditEvent('cancelEdit')
+      } else {
+        setEnumType(null)
+        emitEditEvent('confirmEdit')
+      }
     })
   }
 
   const handleEdit = (inputValue?: unknown) => {
-    cancelEdit()
+    closeEdit()
     setPreviousValue(null)
     let newValue: JsonData
     if (inputValue !== undefined && !isJsEvent(inputValue)) newValue = inputValue as JsonData
@@ -298,11 +324,14 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
       }
     }
     onEdit(newValue, path).then((result) => {
-      if (result === false) revertToData()
-      else if (result) {
+      if (result === false) {
+        revertToData()
+        emitEditEvent('cancelEdit')
+      } else if (result) {
         onError({ code: 'UPDATE_ERROR', message: result }, newValue)
         revertToData()
-      }
+        emitEditEvent('cancelEdit')
+      } else emitEditEvent('confirmEdit')
     })
   }
 
@@ -326,6 +355,7 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
     // non-empty string is a real error. Neither edits this node's value buffer.
     onDelete(value, path).then((result) => {
       if (result) onError({ code: 'DELETE_ERROR', message: result }, value as ValueData)
+      else if (result === undefined) emitEditEvent('delete')
     })
   }
 

--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -125,41 +125,10 @@ export type OnChangeFunction<T = JsonData> = (
  * Category 3 — Observers (run after, return ignored)
  * ========================================================================== */
 
-/** After any error condition (Group A codes). */
-export type OnErrorFunction<T = JsonData> = (
-  props: NodeData<T> & { error: JsonEditorError; errorValue: JsonData }
-) => void
-
-/**
- * The complete interaction-lifecycle stream: value-edit, key-rename and add
- * sessions (start/confirm/cancel), plus the instant `delete`/`move` (one event
- * each). `confirmRename` carries `{ oldKey, newKey }`.
- */
-export type EditEvent<T = JsonData> = NodeData<T> &
-  (
-    | { event: 'startEdit' }
-    | { event: 'confirmEdit' }
-    | { event: 'cancelEdit' }
-    | { event: 'startRename' }
-    | { event: 'confirmRename'; oldKey: CollectionKey; newKey: CollectionKey }
-    | { event: 'cancelRename' }
-    | { event: 'startAdd' }
-    | { event: 'confirmAdd' }
-    | { event: 'cancelAdd' }
-    | { event: 'delete' }
-    | { event: 'move' }
-  )
-
-export type OnEditEventFunction<T = JsonData> = (e: EditEvent<T>) => void
-
-/** On collapse/expand (user click or `editorRef.collapse`). */
-export type OnCollapseFunction<T = JsonData> = (
-  props: NodeData<T> & { collapsed: boolean; includeChildren: boolean }
-) => void
-
-// `OnCopyFunction` (the `onCopy` observer) graduated to `./types` (it's public,
-// wired by the clipboard split). The remaining staging types here are unused
-// until their phases land.
+// All Category 3 observers (`OnErrorFunction`, `EditEvent` / `OnEditEventFunction`,
+// `OnCollapseFunction`) graduated to `./types` (wired in by §17 Phase 3), as did
+// `OnCopyFunction` (the clipboard split). The remaining staging types below are
+// unused until their phases land.
 
 /* ============================================================================
  * Category 4 — Imperative commands (the `editorRef` handle)

--- a/src/contexts/CollapseProvider.tsx
+++ b/src/contexts/CollapseProvider.tsx
@@ -72,7 +72,12 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { type CollectionKey, type OnCollapseFunction, type CollapseState } from '../types'
+import {
+  type CollectionKey,
+  type OnCollapseFunction,
+  type CollapseState,
+  type BuildNodeDataFromPathRef,
+} from '../types'
 
 interface CollapseContext {
   commands: CollapseState[] | null
@@ -85,9 +90,14 @@ const CollapseProviderContext = createContext<CollapseContext | null>(null)
 interface CollapseProps {
   children: React.ReactNode
   onCollapse?: OnCollapseFunction
+  buildNodeDataFromPathRef: BuildNodeDataFromPathRef
 }
 
-export const CollapseProvider = ({ children, onCollapse }: CollapseProps) => {
+export const CollapseProvider = ({
+  children,
+  onCollapse,
+  buildNodeDataFromPathRef,
+}: CollapseProps) => {
   const [inner, setInner] = useState<{ commands: CollapseState[] | null; version: number }>({
     commands: null,
     version: 0,
@@ -116,13 +126,26 @@ export const CollapseProvider = ({ children, onCollapse }: CollapseProps) => {
       const incoming = Array.isArray(state) ? state : [state]
       // Snapshot the commands. They're retained in provider state and
       // replayed to late mounts — a caller mutating the originals after
-      // dispatch must not silently change the pending broadcast. `onCollapse`
-      // still receives the originals (the caller's identity).
+      // dispatch must not silently change the pending broadcast.
       const commands = incoming.map((cmd) => ({ ...cmd, path: [...cmd.path] }))
       setInner((prev) => ({ commands, version: prev.version + 1 }))
-      incoming.forEach((cmd) => onCollapseRef.current?.(cmd))
+      // Fire the `onCollapse` observer once per command, carrying the node's
+      // flat `NodeData` (built from the live document) plus the collapse flags.
+      const onCollapse = onCollapseRef.current
+      if (onCollapse)
+        incoming.forEach((cmd) => {
+          const nodeData = buildNodeDataFromPathRef.current?.(cmd.path)
+          if (nodeData)
+            onCollapse({
+              ...nodeData,
+              collapsed: cmd.collapsed,
+              includeChildren: cmd.includeChildren,
+            })
+        })
     },
-    []
+    // `buildNodeDataFromPathRef` is a stable ref object (read lazily at call
+    // time), so listing it doesn't churn `setCollapseState` / the context value.
+    [buildNodeDataFromPathRef]
   )
 
   const value = useMemo(

--- a/src/contexts/EditingProvider.tsx
+++ b/src/contexts/EditingProvider.tsx
@@ -40,7 +40,9 @@ import {
   type CollectionKey,
   type JsonData,
   type OnEditEventFunction,
+  type EditEvent,
   type EditingState,
+  type BuildNodeDataFromPathRef,
 } from '../types'
 import { editingStatesEqual, isDescendantOf, pathsEqual } from '../utils/pathTools'
 
@@ -64,7 +66,11 @@ export interface EditingStore {
   getSnapshot: () => EditingStateBundle
   getServerSnapshot: () => EditingStateBundle
   startEdit: (path: CollectionKey[], options?: StartEditOptions) => void
+  /** Abort the active session — fires `onEditEvent` cancel* (true user/external cancel). */
   cancelEdit: () => void
+  /** Close the active session silently — no event. Used by commit/confirm flows
+   *  (the terminal event is fired by the node, from the commit outcome). */
+  closeEdit: () => void
   setTabDirection: (dir: TabDirection) => void
   recordPreviousEdit: (path: CollectionKey[]) => void
   setPreviousValue: (value: JsonData | null) => void
@@ -80,7 +86,8 @@ const initialState: EditingStateBundle = {
 }
 
 const createEditingStore = (
-  onEditEventRef: React.RefObject<OnEditEventFunction | undefined>
+  onEditEventRef: React.RefObject<OnEditEventFunction | undefined>,
+  buildNodeDataFromPathRef: BuildNodeDataFromPathRef
 ): EditingStore => {
   let state = initialState
   const listeners = new Set<() => void>()
@@ -100,6 +107,14 @@ const createEditingStore = (
     emit()
   }
 
+  // Fire an `onEditEvent` for a session at `path`, building its `NodeData` from
+  // the live document. No-op if there's no consumer or the accessor isn't ready.
+  const fireEditEvent = (path: CollectionKey[], event: EditEvent['event']) => {
+    if (!onEditEventRef.current) return
+    const nodeData = buildNodeDataFromPathRef.current?.(path)
+    if (nodeData) onEditEventRef.current({ ...nodeData, event } as EditEvent)
+  }
+
   const startEdit = (path: CollectionKey[], options?: StartEditOptions) => {
     const mode = options?.mode ?? 'value'
     const next: EditingState = { path, mode, force: options?.force }
@@ -111,15 +126,29 @@ const createEditingStore = (
       commit({ ...state, currentlyEditingElement: next })
     }
 
-    onEditEventRef.current?.(path, mode === 'key')
+    fireEditEvent(path, mode === 'key' ? 'startRename' : 'startEdit')
   }
 
+  // True cancel (user Esc/✗, node switch, `editorRef.cancelEdit`, search reset):
+  // close the session AND fire cancel*. Snapshot the element before nulling.
   const cancelEdit = () => {
+    const prev = state.currentlyEditingElement
+    cancelOp = null
+    if (prev !== null) {
+      commit({ ...state, currentlyEditingElement: null })
+      fireEditEvent(prev.path, prev.mode === 'key' ? 'cancelRename' : 'cancelEdit')
+    }
+  }
+
+  // Silent close for commit/confirm flows — clears state + cancelOp, fires NO
+  // event (the node fires the terminal confirm*/cancel* from the commit outcome).
+  // Clearing cancelOp is load-bearing: a Tab-commit closes then `startEdit(next)`,
+  // which would otherwise run the stale cancelOp and revert the just-committed value.
+  const closeEdit = () => {
     cancelOp = null
     if (state.currentlyEditingElement !== null) {
       commit({ ...state, currentlyEditingElement: null })
     }
-    onEditEventRef.current?.(null, false)
   }
 
   const setTabDirection = (dir: TabDirection) => {
@@ -149,6 +178,7 @@ const createEditingStore = (
     getServerSnapshot: () => state,
     startEdit,
     cancelEdit,
+    closeEdit,
     setTabDirection,
     recordPreviousEdit,
     setPreviousValue,
@@ -163,9 +193,14 @@ const EditingProviderContext = createContext<EditingStore | null>(null)
 interface EditingProps {
   children: React.ReactNode
   onEditEvent?: OnEditEventFunction
+  buildNodeDataFromPathRef: BuildNodeDataFromPathRef
 }
 
-export const EditingProvider = ({ children, onEditEvent }: EditingProps) => {
+export const EditingProvider = ({
+  children,
+  onEditEvent,
+  buildNodeDataFromPathRef,
+}: EditingProps) => {
   // Keep the latest `onEditEvent` in a ref so an inline consumer callback
   // doesn't force the store to be recreated. Written during render but only
   // ever *read* inside actions (event time), so this is safe.
@@ -173,9 +208,11 @@ export const EditingProvider = ({ children, onEditEvent }: EditingProps) => {
   onEditEventRef.current = onEditEvent
 
   // The store is created once and its identity never changes, so the context
-  // value is stable — `useContext` alone never triggers a re-render.
+  // value is stable — `useContext` alone never triggers a re-render. Both refs
+  // are read only at event time, after `Editor` has populated the accessor.
   const storeRef = useRef<EditingStore | null>(null)
-  if (storeRef.current === null) storeRef.current = createEditingStore(onEditEventRef)
+  if (storeRef.current === null)
+    storeRef.current = createEditingStore(onEditEventRef, buildNodeDataFromPathRef)
 
   return (
     <EditingProviderContext.Provider value={storeRef.current}>
@@ -231,6 +268,7 @@ export const useEditing = () => {
       ...bundle,
       startEdit: store.startEdit,
       cancelEdit: store.cancelEdit,
+      closeEdit: store.closeEdit,
       setTabDirection: store.setTabDirection,
       recordPreviousEdit: store.recordPreviousEdit,
       setPreviousValue: store.setPreviousValue,

--- a/src/contexts/EditingProvider.tsx
+++ b/src/contexts/EditingProvider.tsx
@@ -92,10 +92,18 @@ const createEditingStore = (
   let state = initialState
   const listeners = new Set<() => void>()
 
-  // cancelOp fires imperatively before transitioning to a new edit, letting the
-  // previously-editing node's UI reset. Held in a closure var (not state) so
-  // installing/clearing it never notifies subscribers.
+  // cancelOp fires imperatively when a session ends without a confirm — node
+  // switch, explicit cancel (Esc/✗), or external cancel (search reset,
+  // `editorRef.cancelEdit`) — so the previously-editing node can reset its
+  // local UI buffers. Held in a closure var (not state) so installing/clearing
+  // it never notifies subscribers.
   let cancelOp: (() => void) | null = null
+
+  // Re-entrancy guard. A registered cancelOp may itself call cancelEdit
+  // (some nodes route their user-cancel handler through the store); the
+  // recursive call no-ops so the outer flow owns the single state-clear and
+  // single cancel* emission.
+  let cancelling = false
 
   const emit = () => listeners.forEach((listener) => listener())
 
@@ -118,9 +126,29 @@ const createEditingStore = (
   const startEdit = (path: CollectionKey[], options?: StartEditOptions) => {
     const mode = options?.mode ?? 'value'
     const next: EditingState = { path, mode, force: options?.force }
+    const prev = state.currentlyEditingElement
+    const isSwitch = prev !== null && !editingStatesEqual(prev, next)
 
-    if (cancelOp) cancelOp()
+    // Run the outgoing session's UI cleanup before installing the new one.
+    // If that cancelOp itself routed through `cancelEdit` (some nodes do),
+    // it will have cleared state and fired the cancel* already — the
+    // post-check below avoids a double-fire.
+    const op = cancelOp
+    cancelOp = null
+    if (op) op()
+
     cancelOp = options?.cancelOp ?? null
+
+    // Fire cancel* for the displaced session if the cancelOp didn't already
+    // tear it down. `state.currentlyEditingElement` still pointing at `prev`
+    // means no recursive cancelEdit fired the event.
+    if (
+      isSwitch &&
+      state.currentlyEditingElement !== null &&
+      editingStatesEqual(state.currentlyEditingElement, prev)
+    ) {
+      fireEditEvent(prev.path, prev.mode === 'key' ? 'cancelRename' : 'cancelEdit')
+    }
 
     if (!editingStatesEqual(state.currentlyEditingElement, next)) {
       commit({ ...state, currentlyEditingElement: next })
@@ -129,14 +157,25 @@ const createEditingStore = (
     fireEditEvent(path, mode === 'key' ? 'startRename' : 'startEdit')
   }
 
-  // True cancel (user Esc/✗, node switch, `editorRef.cancelEdit`, search reset):
-  // close the session AND fire cancel*. Snapshot the element before nulling.
+  // True cancel (user Esc/✗, `editorRef.cancelEdit`, search reset): run the
+  // session's UI cleanup, close the session, AND fire cancel*. Snapshot
+  // `prev` before nulling so the event uses the prior path/mode.
   const cancelEdit = () => {
+    if (cancelling) return
     const prev = state.currentlyEditingElement
-    cancelOp = null
-    if (prev !== null) {
-      commit({ ...state, currentlyEditingElement: null })
-      fireEditEvent(prev.path, prev.mode === 'key' ? 'cancelRename' : 'cancelEdit')
+    cancelling = true
+    try {
+      const op = cancelOp
+      cancelOp = null
+      if (op) op()
+      if (prev !== null) {
+        if (state.currentlyEditingElement !== null) {
+          commit({ ...state, currentlyEditingElement: null })
+        }
+        fireEditEvent(prev.path, prev.mode === 'key' ? 'cancelRename' : 'cancelEdit')
+      }
+    } finally {
+      cancelling = false
     }
   }
 

--- a/src/contexts/TreeStateProvider.tsx
+++ b/src/contexts/TreeStateProvider.tsx
@@ -15,17 +15,29 @@ import React from 'react'
 import { EditingProvider } from './EditingProvider'
 import { CollapseProvider } from './CollapseProvider'
 import { DragSourceProvider } from '../hooks/DragSourceProvider'
-import { type OnEditEventFunction, type OnCollapseFunction } from '../types'
+import {
+  type OnEditEventFunction,
+  type OnCollapseFunction,
+  type BuildNodeDataFromPathRef,
+} from '../types'
 
 interface TreeStateProps {
   children: React.ReactNode
   onEditEvent?: OnEditEventFunction
   onCollapse?: OnCollapseFunction
+  // Bridges live `NodeData` construction from the inner `Editor` (which owns the
+  // data) into these provider contexts, which only know a node's path.
+  buildNodeDataFromPathRef: BuildNodeDataFromPathRef
 }
 
-export const TreeStateProvider = ({ children, onEditEvent, onCollapse }: TreeStateProps) => (
-  <EditingProvider onEditEvent={onEditEvent}>
-    <CollapseProvider onCollapse={onCollapse}>
+export const TreeStateProvider = ({
+  children,
+  onEditEvent,
+  onCollapse,
+  buildNodeDataFromPathRef,
+}: TreeStateProps) => (
+  <EditingProvider onEditEvent={onEditEvent} buildNodeDataFromPathRef={buildNodeDataFromPathRef}>
+    <CollapseProvider onCollapse={onCollapse} buildNodeDataFromPathRef={buildNodeDataFromPathRef}>
       <DragSourceProvider>{children}</DragSourceProvider>
     </CollapseProvider>
   </EditingProvider>

--- a/src/hooks/useCommon.ts
+++ b/src/hooks/useCommon.ts
@@ -22,11 +22,11 @@ interface CommonProps {
 
 export const useCommon = ({ props, collapsed }: CommonProps) => {
   const {
-    data,
     nodeData: incomingNodeData,
     parentData,
     onRename,
     onError: onErrorCallback,
+    onEditEvent,
     getLatestData,
     showErrorMessages,
     restrictEditFilter,
@@ -36,7 +36,7 @@ export const useCommon = ({ props, collapsed }: CommonProps) => {
     translate,
     errorMessageTimeout,
   } = props
-  const { cancelEdit } = useEditingStore()
+  const { closeEdit } = useEditingStore()
   const [error, setError] = useState<string | null>(null)
 
   const nodeData = { ...incomingNodeData, collapsed }
@@ -75,23 +75,20 @@ export const useCommon = ({ props, collapsed }: CommonProps) => {
 
   // `onError` keeps a stable identity (it's a node prop, threaded down and
   // compared by the memo), so it can't close over the live document or this
-  // node's `data`/`name`/`path` — once `onErrorCallback` is stabilized upstream
-  // the closure freezes. Read the document from `getLatestData()` and the
-  // per-node args from a ref-to-latest.
-  const onErrorArgsRef = useRef({ data, name, path })
-  onErrorArgsRef.current = { data, name, path }
+  // node's churning `nodeData` — once `onErrorCallback` is stabilized upstream
+  // the closure freezes. Read this node's `NodeData` from a ref-to-latest and
+  // the live document from `getLatestData()` (so the flat payload is current).
+  const nodeDataRef = useRef(nodeData)
+  nodeDataRef.current = nodeData
   const onError = useCallback(
     (error: JsonEditorError, errorValue: JsonData | string) => {
       showError(error.message)
       if (onErrorCallback) {
-        const { data: liveData, name: liveName, path: livePath } = onErrorArgsRef.current
         onErrorCallback({
-          currentData: getLatestData(),
-          errorValue,
-          currentValue: liveData,
-          name: liveName,
-          path: livePath,
+          ...nodeDataRef.current,
+          fullData: getLatestData(),
           error,
+          errorValue,
         })
       }
     },
@@ -103,23 +100,30 @@ export const useCommon = ({ props, collapsed }: CommonProps) => {
   )
 
   const handleEditKey = (newKey: string) => {
-    cancelEdit()
-    if (name === newKey) return
+    closeEdit()
+    // No-op rename (unchanged key) reports as a cancel (session closed, no change).
+    if (name === newKey) {
+      onEditEvent?.({ ...nodeData, event: 'cancelRename' })
+      return
+    }
     if (!parentData) return
     const existingKeys = Object.keys(parentData)
     if (existingKeys.includes(newKey)) {
       onError({ code: 'KEY_EXISTS', message: translate('ERROR_KEY_EXISTS', nodeData) }, newKey)
+      onEditEvent?.({ ...nodeData, event: 'cancelRename' })
       return
     }
 
     // A rename is a first-class `event: 'rename'` update — `onRename` rebuilds
-    // the parent (preserving key order) and commits the whole document.
-    onRename(path, newKey).then((error) => {
-      // `false` means the consumer's `onUpdate` returned `null` (silent cancel);
-      // a non-empty string is a real error to surface.
-      if (error) {
-        onError({ code: 'UPDATE_ERROR', message: error }, newKey as ValueData)
-      }
+    // the parent (preserving key order) and commits the whole document. The
+    // session terminates with `confirmRename` (committed) or `cancelRename`
+    // (rejected/aborted); `confirmRename` carries the old + new keys.
+    onRename(path, newKey).then((result) => {
+      if (result === false) onEditEvent?.({ ...nodeData, event: 'cancelRename' })
+      else if (result) {
+        onError({ code: 'UPDATE_ERROR', message: result }, newKey as ValueData)
+        onEditEvent?.({ ...nodeData, event: 'cancelRename' })
+      } else onEditEvent?.({ ...nodeData, event: 'confirmRename', oldKey: name, newKey })
     })
   }
 

--- a/src/hooks/useDragNDrop.tsx
+++ b/src/hooks/useDragNDrop.tsx
@@ -144,9 +144,11 @@ export const useDragNDrop = ({
     ) {
       onError({ code: 'KEY_EXISTS', message: translate('ERROR_KEY_EXISTS', nodeData) }, sourceKey)
     } else {
-      onMove(dragSource.path, path, position).then((error) => {
-        if (error)
-          onError({ code: 'UPDATE_ERROR', message: error }, nodeData.value as CollectionData)
+      onMove(dragSource.path, path, position).then((result) => {
+        if (result)
+          onError({ code: 'UPDATE_ERROR', message: result }, nodeData.value as CollectionData)
+        // `move` onEditEvent fires from the internal `onMove` handler (it owns
+        // the SOURCE node's NodeData) — not here, where only the drop target is.
       })
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
   type OnChangeFunction,
   type OnErrorFunction,
   type OnEditEventFunction,
+  type EditEvent,
   type OnCollapseFunction,
   type JsonEditorError,
   type JsonEditorErrorCode,

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,7 @@ export type JsonEditorErrorCode =
   | 'DELETE_ERROR' // a delete was rejected
   | 'KEY_EXISTS' // a new/renamed key collides with an existing sibling
   | 'INVALID_JSON' // raw JSON typed into the editor failed to parse
+  | 'CLIPBOARD_ERROR' // a copy-to-clipboard write failed (onCopy)
   // Group B — imperative command flow (Category 4)
   | 'PATH_NOT_FOUND' // a command targeted a path that doesn't exist in the current data
   | 'RESTRICTED' // a command's action is blocked by an `allow*`/`restrict*` filter
@@ -242,14 +243,10 @@ export type OnChangeFunction<T = JsonData> = (
   props: NodeData<T> & { newValue: ValueData }
 ) => ValueData
 
-export type OnErrorFunction<T = JsonData> = (props: {
-  currentData: T
-  errorValue: JsonData
-  currentValue: JsonData
-  name: CollectionKey
-  path: CollectionKey[]
-  error: JsonEditorError
-}) => unknown
+/** Observer (Cat 3): after any error condition (Group A codes). Flat `NodeData`. */
+export type OnErrorFunction<T = JsonData> = (
+  props: NodeData<T> & { error: JsonEditorError; errorValue: JsonData }
+) => void
 
 export type FilterFunction<T = JsonData> = (input: NodeData<T>) => boolean
 export type TypeFilterFunction<T = JsonData> = (input: NodeData<T>) => boolean | TypeOptions
@@ -268,14 +265,13 @@ export type NewKeyOptionsFunction<T = JsonData> = (input: NodeData<T>) => string
 export type CopyType = 'path' | 'value'
 
 // Observer (Cat 3): fires after a copy-to-clipboard. Enablement is the
-// `allowClipboard` boolean (Cat 1). A failed copy carries `error.message`
-// (clipboard failures aren't part of the §17 error-code taxonomy).
+// `allowClipboard` boolean (Cat 1). A failed copy carries a `CLIPBOARD_ERROR`.
 export type OnCopyFunction<T = JsonData> = (
   props: NodeData<T> & {
     success: boolean
     stringValue: string
     type: CopyType
-    error?: { message: string }
+    error?: JsonEditorError
   }
 ) => void
 
@@ -286,17 +282,43 @@ export type CompareFunction = (
 
 export type SortFunction = <T>(arr: T[], nodeMap: (input: T) => [string | number, unknown]) => void
 
-export type OnEditEventFunction = (path: (CollectionKey | null)[] | null, isKey: boolean) => void
+/**
+ * Observer (Cat 3): the complete interaction-lifecycle stream. Value-edit,
+ * key-rename and add sessions each open with a `start*`, then terminate with
+ * `confirm*` (committed) or `cancel*` (closed without a commit — incl. a no-op
+ * confirm or a rejected/aborted change). `delete`/`move` are instant (one event
+ * on commit). `confirmRename` carries `{ oldKey, newKey }`. Absorbs the old
+ * `onRenameProperty` (§12).
+ */
+export type EditEvent<T = JsonData> = NodeData<T> &
+  (
+    | { event: 'startEdit' }
+    | { event: 'confirmEdit' }
+    | { event: 'cancelEdit' }
+    | { event: 'startRename' }
+    | { event: 'confirmRename'; oldKey: CollectionKey; newKey: CollectionKey }
+    | { event: 'cancelRename' }
+    | { event: 'startAdd' }
+    | { event: 'confirmAdd' }
+    | { event: 'cancelAdd' }
+    | { event: 'delete' }
+    | { event: 'move' }
+  )
 
-// Definition to externally set Collapse state -- also passed to OnCollapse
-// function
+export type OnEditEventFunction<T = JsonData> = (e: EditEvent<T>) => void
+
+// Definition to externally set Collapse state -- the `editorRef.collapse`
+// command input (NOT the OnCollapse observer payload, which is flat NodeData).
 export interface CollapseState {
   path: CollectionKey[]
   collapsed: boolean
   includeChildren: boolean
 }
 
-export type OnCollapseFunction = (input: CollapseState) => void
+/** Observer (Cat 3): on collapse/expand (user click or `editorRef.collapse`). */
+export type OnCollapseFunction<T = JsonData> = (
+  props: NodeData<T> & { collapsed: boolean; includeChildren: boolean }
+) => void
 
 // Internal update. Resolves to an error message (`string`), `false` (the
 // consumer returned `null` — silent cancel; revert the display, no error), or
@@ -311,6 +333,13 @@ export type InternalUpdateFunction = (
 // Key rename (a first-class `event: 'rename'` update). `path`/`newKey` are the
 // OLD node path and the new key.
 export type InternalRenameFunction = (path: CollectionKey[], newKey: string) => InternalResult
+
+// Builds a node's full `NodeData` from its path against the LIVE document.
+// Bridged via a ref from the inner `Editor` into the editing/collapse providers
+// (its ancestors), so observer events fired from those contexts (`onEditEvent`
+// start*/cancel*, `onCollapse` broadcast) can carry a flat `NodeData`.
+export type BuildNodeDataFromPath = (path: CollectionKey[]) => NodeData
+export type BuildNodeDataFromPathRef = React.RefObject<BuildNodeDataFromPath | undefined>
 
 // For drag-n-drop
 export type Position = 'above' | 'below'

--- a/test/JsonEditor.test.tsx
+++ b/test/JsonEditor.test.tsx
@@ -3,7 +3,12 @@ import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { JsonEditor } from '../src/JsonEditor'
 import { JsonViewer } from '../src/JsonViewer'
-import { type FilterFunction, type JsonViewerHandle, type EditEvent } from '../src/types'
+import {
+  type FilterFunction,
+  type JsonEditorHandle,
+  type JsonViewerHandle,
+  type EditEvent,
+} from '../src/types'
 
 const noop = () => {}
 
@@ -801,6 +806,60 @@ describe('JsonEditor — §17 onEditEvent lifecycle stream', () => {
     expect(seq).toContain('confirmEdit')
     expect(seq.filter((e) => e === 'startEdit')).toHaveLength(2)
     expect(seq).not.toContain('cancelEdit')
+  })
+
+  test('node-switch fires cancelEdit for the displaced session before startEdit for the new one', async () => {
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    render(
+      <JsonEditor data={{ a: 'first', b: 'second' }} setData={noop} onEditEvent={onEditEvent} />
+    )
+
+    // Open edit on `a`, then click Edit on `b` while `a` is still active.
+    await user.dblClick(screen.getByText('"first"'))
+    // Typed-but-uncommitted text on `a`. The displaced session must report as
+    // a cancel (not a silent close).
+    await user.clear(screen.getByRole('textbox'))
+    await user.type(screen.getByRole('textbox'), 'edited-a')
+    await user.dblClick(screen.getByText('"second"'))
+
+    const seq = onEditEvent.mock.calls.map(([e]) => e.event)
+    expect(seq).toEqual(['startEdit', 'cancelEdit', 'startEdit'])
+    expect(onEditEvent.mock.calls[0][0]).toMatchObject({ key: 'a' })
+    expect(onEditEvent.mock.calls[1][0]).toMatchObject({ event: 'cancelEdit', key: 'a' })
+    expect(onEditEvent.mock.calls[2][0]).toMatchObject({ event: 'startEdit', key: 'b' })
+  })
+
+  test('editorRef.cancelEdit fires cancelEdit and clears the local edit buffer', async () => {
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    const ref = createRef<JsonEditorHandle>()
+    render(
+      <JsonEditor
+        data={{ x: 'hello' }}
+        setData={noop}
+        onEditEvent={onEditEvent}
+        editorRef={ref}
+      />
+    )
+
+    await user.dblClick(screen.getByText('"hello"'))
+    await user.clear(screen.getByRole('textbox'))
+    await user.type(screen.getByRole('textbox'), 'typed-but-not-committed')
+
+    // External cancel via the imperative handle.
+    act(() => {
+      ref.current!.cancelEdit()
+    })
+
+    // The lifecycle event fires.
+    const seq = onEditEvent.mock.calls.map(([e]) => e.event)
+    expect(seq).toEqual(['startEdit', 'cancelEdit'])
+
+    // And the local buffer was reverted — re-opening the node shows the
+    // original value, not the typed-but-uncommitted text.
+    await user.dblClick(screen.getByText('"hello"'))
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('hello')
   })
 })
 

--- a/test/JsonEditor.test.tsx
+++ b/test/JsonEditor.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { JsonEditor } from '../src/JsonEditor'
 import { JsonViewer } from '../src/JsonViewer'
-import { type FilterFunction, type JsonViewerHandle } from '../src/types'
+import { type FilterFunction, type JsonViewerHandle, type EditEvent } from '../src/types'
 
 const noop = () => {}
 
@@ -653,6 +653,126 @@ describe('JsonEditor — §17 onUpdate event discriminant', () => {
   // but exercising it needs a full drag-drop simulation — deferred with the
   // rest of the DnD test gap (#270).
   test.todo('onUpdate receives event:"move" on a drag-drop (needs DnD simulation — #270)')
+})
+
+describe('JsonEditor — §17 onEditEvent lifecycle stream', () => {
+  // A session ends in confirm* (committed) or cancel* (closed without a commit).
+  test('value edit: startEdit → confirmEdit on a real change', async () => {
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    render(<JsonEditor data={{ x: 'hello' }} setData={noop} onEditEvent={onEditEvent} />)
+
+    await user.dblClick(screen.getByText('"hello"'))
+    const input = screen.getByRole('textbox')
+    await user.clear(input)
+    await user.type(input, 'world{Enter}')
+
+    const seq = onEditEvent.mock.calls.map(([e]) => e.event)
+    expect(seq).toEqual(['startEdit', 'confirmEdit'])
+  })
+
+  test('value edit: startEdit → cancelEdit on a no-op confirm (no change)', async () => {
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    render(<JsonEditor data={{ x: 'hello' }} setData={noop} onEditEvent={onEditEvent} />)
+
+    await user.dblClick(screen.getByText('"hello"'))
+    // Confirm without changing anything.
+    await user.type(screen.getByRole('textbox'), '{Enter}')
+
+    const seq = onEditEvent.mock.calls.map(([e]) => e.event)
+    expect(seq).toEqual(['startEdit', 'cancelEdit'])
+  })
+
+  test('value edit: startEdit → cancelEdit on Escape', async () => {
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    render(<JsonEditor data={{ x: 'hello' }} setData={noop} onEditEvent={onEditEvent} />)
+
+    await user.dblClick(screen.getByText('"hello"'))
+    await user.type(screen.getByRole('textbox'), 'abc{Escape}')
+
+    const seq = onEditEvent.mock.calls.map(([e]) => e.event)
+    expect(seq).toEqual(['startEdit', 'cancelEdit'])
+  })
+
+  test('key rename: startRename → confirmRename with old + new keys', async () => {
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    render(<JsonEditor data={{ a: 1, oldName: 2 }} setData={noop} onEditEvent={onEditEvent} />)
+
+    await user.dblClick(screen.getByText('oldName'))
+    const keyInput = screen.getByDisplayValue('oldName') as HTMLInputElement
+    await user.clear(keyInput)
+    await user.type(keyInput, 'newName{Enter}')
+
+    const seq = onEditEvent.mock.calls.map(([e]) => e.event)
+    expect(seq).toEqual(['startRename', 'confirmRename'])
+    const confirm = onEditEvent.mock.calls.map(([e]) => e)[1]
+    expect(confirm).toMatchObject({
+      event: 'confirmRename',
+      key: 'oldName',
+      path: ['oldName'],
+      oldKey: 'oldName',
+      newKey: 'newName',
+    })
+  })
+
+  test('add (object): startAdd → confirmAdd; and startAdd → cancelAdd on Escape', async () => {
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    const { container } = render(
+      <JsonEditor data={{ existing: 'value' }} setData={noop} onEditEvent={onEditEvent} showIconTooltips />
+    )
+
+    // Open + confirm
+    await user.click(screen.getByTitle('Add'))
+    const newKeyInput = container.querySelector('input.jer-input-new-key') as HTMLInputElement
+    await user.clear(newKeyInput)
+    await user.type(newKeyInput, 'fresh{Enter}')
+    expect(onEditEvent.mock.calls.map(([e]) => e.event)).toEqual(['startAdd', 'confirmAdd'])
+
+    // Open + cancel
+    onEditEvent.mockClear()
+    await user.click(screen.getByTitle('Add'))
+    const reopened = container.querySelector('input.jer-input-new-key') as HTMLInputElement
+    await user.type(reopened, '{Escape}')
+    expect(onEditEvent.mock.calls.map(([e]) => e.event)).toEqual(['startAdd', 'cancelAdd'])
+  })
+
+  test('delete fires a single "delete" event', async () => {
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    render(
+      <JsonEditor data={{ x: 'hi', y: 'bye' }} setData={noop} onEditEvent={onEditEvent} showIconTooltips />
+    )
+
+    const xRow = screen.getByText('"hi"').closest('.jer-component') as HTMLElement
+    await user.click(xRow.querySelector('[title="Delete"]') as HTMLElement)
+
+    const seq = onEditEvent.mock.calls.map(([e]) => e.event)
+    expect(seq).toEqual(['delete'])
+    expect(onEditEvent.mock.calls[0][0]).toMatchObject({ event: 'delete', key: 'x', path: ['x'] })
+  })
+
+  test('Tab-commit fires confirmEdit then startEdit(next) — no stray cancelEdit', async () => {
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    render(<JsonEditor data={{ a: 'x', b: 'y' }} setData={noop} onEditEvent={onEditEvent} />)
+
+    await user.dblClick(screen.getByText('"x"'))
+    await user.clear(screen.getByRole('textbox'))
+    await user.type(screen.getByRole('textbox'), 'changed{Tab}')
+
+    // The commit is async (`.then`), so `confirmEdit` lands after the synchronous
+    // advance to the next node — order is start, start(next), confirm. The
+    // load-bearing guard: a `confirmEdit` fired and there's NO stray `cancelEdit`
+    // (which would mean the stale cancelOp reverted the just-committed value).
+    const seq = onEditEvent.mock.calls.map(([e]) => e.event)
+    expect(seq).toContain('confirmEdit')
+    expect(seq.filter((e) => e === 'startEdit')).toHaveLength(2)
+    expect(seq).not.toContain('cancelEdit')
+  })
 })
 
 describe('JsonEditor — restrictions and callbacks', () => {

--- a/test/apiTypes.test.ts
+++ b/test/apiTypes.test.ts
@@ -19,14 +19,18 @@ import type {
   EventInterceptFunction,
   UpdateFunction,
   OnChangeFunction,
-  OnErrorFunction,
-  OnEditEventFunction,
-  OnCollapseFunction,
   CommandResult,
   JsonEditorHandle,
 } from '../src/apiTypes'
-// `OnCopyFunction` graduated to the public surface with the clipboard split.
-import type { JsonData, OnCopyFunction } from '../src/types'
+// Graduated to the public surface: `OnCopyFunction` (clipboard split), and the
+// Category-3 observers `OnErrorFunction` / `OnEditEventFunction` / `OnCollapseFunction` (Phase 3).
+import type {
+  JsonData,
+  OnCopyFunction,
+  OnErrorFunction,
+  OnEditEventFunction,
+  OnCollapseFunction,
+} from '../src/types'
 
 // --- Cat 1: async-capable gates -------------------------------------------
 

--- a/test/clipboard.test.tsx
+++ b/test/clipboard.test.tsx
@@ -55,4 +55,25 @@ describe('onCopy', () => {
       )
     )
   })
+
+  test('a failed copy reports a CLIPBOARD_ERROR (§17: error is a JsonEditorError)', async () => {
+    const user = userEvent.setup()
+    const writeText = jest.fn().mockRejectedValue(new Error('denied'))
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+
+    const onCopy = jest.fn()
+    render(<JsonEditor data={{ greeting: 'hello' }} setData={noop} onCopy={onCopy} showIconTooltips />)
+
+    const row = screen.getByText('"hello"').closest('.jer-component') as HTMLElement
+    await user.click(row.querySelector('[title="Copy to clipboard"]') as HTMLElement)
+
+    await waitFor(() =>
+      expect(onCopy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: { code: 'CLIPBOARD_ERROR', message: 'denied' },
+        })
+      )
+    )
+  })
 })

--- a/test/collapseBroadcasts.test.tsx
+++ b/test/collapseBroadcasts.test.tsx
@@ -169,7 +169,10 @@ describe('Collapse broadcasts via editorRef handle', () => {
     act(() => ref.current!.collapse(command))
 
     expect(onCollapse).toHaveBeenCalledTimes(1)
-    expect(onCollapse).toHaveBeenCalledWith(command)
+    // Flat NodeData payload (§17) built from the command's path, plus the flags.
+    expect(onCollapse).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'a', path: ['a'], collapsed: true, includeChildren: false })
+    )
   })
 
   test('9. an array of commands applies each command independently', () => {
@@ -341,7 +344,9 @@ describe('Collapse broadcasts via editorRef handle', () => {
 
     act(() => ref.current!.collapse(command))
 
-    expect(onCollapseV2).toHaveBeenCalledWith(command)
+    expect(onCollapseV2).toHaveBeenCalledWith(
+      expect.objectContaining({ path: ['a'], collapsed: true, includeChildren: false })
+    )
     expect(onCollapseV1).not.toHaveBeenCalled()
   })
 })

--- a/test/renderScope.test.tsx
+++ b/test/renderScope.test.tsx
@@ -18,7 +18,7 @@ import { useState } from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { JsonEditor } from '../src/JsonEditor'
-import { type OnChangeFunction, type OnCollapseFunction } from '../src/types'
+import { type OnChangeFunction, type OnCollapseFunction, type OnErrorFunction } from '../src/types'
 import { makeRenderSpy } from './helpers/renderSpy'
 
 // A controlled host so `setData` commits actually re-render the editor, the
@@ -413,14 +413,15 @@ describe('Stage D — consumer callbacks stay fresh through the memo boundary', 
     })
   })
 
-  // Same staleness class for `onError`: `useCommon` builds its `currentData` from
-  // `nodeData.fullData`, which a bailed sibling keeps stale. Triggering an error
-  // in a subtree that bailed on an earlier commit must still report the live doc.
+  // Same staleness class for `onError`: `useCommon` builds its `fullData` from
+  // `getLatestData()`, not the `nodeData.fullData` a bailed sibling keeps stale.
+  // Triggering an error in a subtree that bailed on an earlier commit must still
+  // report the live doc.
   test('onError reports the live document, not a stale snapshot', async () => {
     const user = userEvent.setup()
-    let seenCurrentData: unknown = null
-    const onError = jest.fn((p: { currentData: unknown }) => {
-      seenCurrentData = p.currentData
+    let seenFullData: unknown = null
+    const onError = jest.fn<void, Parameters<OnErrorFunction>>((p) => {
+      seenFullData = p.fullData
     })
     const Host = () => {
       const [data, setData] = useState<object>({ a: 'aval', obj: { x: 1 } })
@@ -441,6 +442,6 @@ describe('Stage D — consumer callbacks stay fresh through the memo boundary', 
     fireEvent.keyDown(ta, { key: 'Enter', metaKey: true })
 
     expect(onError).toHaveBeenCalled()
-    expect(seenCurrentData).toEqual({ a: 'aval2', obj: { x: 1 } })
+    expect(seenFullData).toEqual({ a: 'aval2', obj: { x: 1 } })
   })
 })

--- a/test/sliceIsolation.test.tsx
+++ b/test/sliceIsolation.test.tsx
@@ -11,7 +11,15 @@ import { useState } from 'react'
 import { act, render } from '@testing-library/react'
 import { TreeStateProvider, useEditing, useCollapse } from '../src/contexts'
 import { useDragSource } from '../src/hooks/DragSourceProvider'
-import { type CollectionKey, type CollapseState } from '../src/types'
+import {
+  type CollectionKey,
+  type CollapseState,
+  type BuildNodeDataFromPathRef,
+} from '../src/types'
+
+// Slice-isolation tests don't fire observer events, so the NodeData accessor is
+// never invoked — a stub ref satisfies the provider prop.
+const stubBuildNodeDataFromPathRef: BuildNodeDataFromPathRef = { current: undefined }
 
 type DragSourceValue = { path: CollectionKey[] | null }
 
@@ -58,7 +66,7 @@ const DragOnlyConsumer = () => {
 
 const renderTree = () =>
   render(
-    <TreeStateProvider>
+    <TreeStateProvider buildNodeDataFromPathRef={stubBuildNodeDataFromPathRef}>
       <Harness />
       <EditingOnlyConsumer />
       <CollapseOnlyConsumer />
@@ -136,7 +144,7 @@ describe('Tree-state providers — slice isolation', () => {
       const [, setCounter] = useState(0)
       bumpOuterCounter = () => setCounter((n) => n + 1)
       return (
-        <TreeStateProvider>
+        <TreeStateProvider buildNodeDataFromPathRef={stubBuildNodeDataFromPathRef}>
           <Observer />
         </TreeStateProvider>
       )


### PR DESCRIPTION
Phase 3 of the §17 API standardisation ([#298](https://github.com/CarlosNZ/json-edit-react/issues/298), umbrella [#289](https://github.com/CarlosNZ/json-edit-react/issues/289)). Reshapes **Category 3 — the observers** onto the flat `NodeData` payload, and turns `onEditEvent` into the full interaction-lifecycle stream.

Stacks on Phase 2: **base = `feat/v2.0-api-phase-2`** ([#303](https://github.com/CarlosNZ/json-edit-react/pull/303)).

## What changed

- **`onEditEvent`** — from `(path, isKey) => void` to a discriminated **lifecycle stream**: `startEdit`/`confirmEdit`/`cancelEdit`, `startRename`/`confirmRename`(+`oldKey`,`newKey`)/`cancelRename`, `startAdd`/`confirmAdd`/`cancelAdd`, plus instant `delete`/`move` — each on flat `NodeData`. Absorbs `onRenameProperty` (§12).
- **`onError`** / **`onCollapse`** — now flat `NodeData & { … }`. (`CollapseState` stays as the `editorRef.collapse` command *input*.)
- **`onCopy`** — `error` aligned to the canonical `JsonEditorError` (new **`CLIPBOARD_ERROR`** code), per the decision to reconcile it with the rest of the error surface.

### Lifecycle semantics (decided)

A value/key/add session opens with a `start*` and ends in **exactly one** of `confirm*` (committed) or `cancel*` — where `cancel*` covers an explicit cancel, **a no-op confirm** (closing with no change), *and* a change the consumer's `onUpdate` rejected/aborted (which also fires `onError`). `delete`/`move` fire a single event on commit. Documented asymmetries: add events describe the parent collection; array-adds are instant (`confirmAdd` only); a type-change mid-session commits (`confirmEdit`) while the session stays open.

## Mechanics

- Graduate `EditEvent` / `OnEditEventFunction` + flat `OnErrorFunction` / `OnCollapseFunction` from `apiTypes.ts` → `types.ts`; export `EditEvent`.
- Editing store gains a silent **`closeEdit`** (clears `cancelOp` — without that, a Tab-commit's `startEdit(next)` would run the stale `cancelOp` and revert the just-committed value). Commit/confirm flows use `closeEdit`; **`cancelEdit`** fires `cancel*` (snapshotting the element before nulling) for true/external cancels (Esc, node-switch, `editorRef.cancelEdit`, search). `start*` fires from `startEdit`.
- Terminal `confirm*`/`cancel*`/`delete`/add events fire from the **node handlers** (which hold both `nodeData` and the commit outcome, co-located with `onError`); **`move`** fires from the internal `onMove` (the only place with the *source* node's `NodeData`). `onEdit`'s no-op now returns the Phase-2 `false` sentinel so the node reports it as a cancel.
- A shared **`buildNodeDataFromPath`** ref bridges live `NodeData` construction from the inner `Editor` into the editing/collapse providers (its ancestors) for the events those contexts fire from just a path.

## Tests

`pnpm test` green (282 pass, 2 todo). Rewrote `renderScope` onError (`currentData`→`fullData`) and `collapseBroadcasts` (flat payload); added a new `onEditEvent` lifecycle suite (start→confirm, start→cancel on no-op/Escape, rename with old/new keys, add confirm+cancel, delete, and the Tab-commit no-stray-cancel guard) and an `onCopy` `CLIPBOARD_ERROR` case. Full drag-`move` simulation stays deferred to [#270](https://github.com/CarlosNZ/json-edit-react/issues/270) (`test.todo`).

`pnpm compile` / `pnpm lint` / `pnpm build` clean; demo typechecks against local source.

## Docs

README "Event callbacks" rewritten for the stream + flat `onError`/`onCollapse`/`onCopy`; migration-guide §10; roadmap `CLIPBOARD_ERROR`.

## Changeset

Published-surface break; per the Phase 0/1/2 precedent, deferring a single changeset to the §17 umbrella merge — flag if you'd prefer one now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)