### PR TITLE
Add dedicated ERROR_RENAME / ERROR_MOVE keys + RENAME_ERROR / MOVE_ERROR codes (#308)

### DIFF
--- a/.changeset/error-rename-move-codes.md
+++ b/.changeset/error-rename-move-codes.md
@@ -1,0 +1,7 @@
+---
+'json-edit-react': minor
+---
+
+Add dedicated `ERROR_RENAME` / `ERROR_MOVE` localisation keys and `RENAME_ERROR` / `MOVE_ERROR` error codes for rejected rename/move operations (#308).
+
+A rejected rename/move (`onUpdate` returning `false`) now surfaces an operation-specific message ("Rename unsuccessful" / "Move unsuccessful") and a matching `onError` code (`RENAME_ERROR` / `MOVE_ERROR`), giving these first-class events full parity with `add`/`delete`. Previously both reused the generic `ERROR_UPDATE` message and `UPDATE_ERROR` code. The two new codes are additive members of the public `JsonEditorErrorCode` union.

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Normally, the component will display simple error messages whenever an error con
     errorValue,   // the erroneous value that failed to update the property
     error: {      // a JsonEditorError
       code,       // one of 'UPDATE_ERROR' | 'DELETE_ERROR' | 'ADD_ERROR'
-                  //   | 'INVALID_JSON' | 'KEY_EXISTS'
+                  //   | 'RENAME_ERROR' | 'MOVE_ERROR' | 'INVALID_JSON' | 'KEY_EXISTS'
       message     // the (localised) error message that would be displayed
     }
 }
@@ -987,6 +987,8 @@ Localise your implementation (or just customise the default messages) by passing
   ERROR_UPDATE: 'Update unsuccessful',
   ERROR_DELETE: 'Delete unsuccessful',
   ERROR_ADD: 'Adding node unsuccessful',
+  ERROR_RENAME: 'Rename unsuccessful',
+  ERROR_MOVE: 'Move unsuccessful',
   DEFAULT_STRING: 'New data!',
   DEFAULT_NEW_KEY: 'key',
   SHOW_LESS: '(Show less)',

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -410,6 +410,21 @@ The error type reported to `onError` (and accepted in an `onUpdate` `{ error }` 
 + import { type JsonEditorError } from 'json-edit-react'
 ```
 
+### New localisation keys: `ERROR_RENAME` / `ERROR_MOVE`
+
+Rejected `rename` and `move` operations now show operation-specific messages (`'Rename unsuccessful'` / `'Move unsuccessful'`) instead of the generic `'Update unsuccessful'`, mirroring `ERROR_ADD` / `ERROR_DELETE`. Their `onError` codes are likewise `RENAME_ERROR` / `MOVE_ERROR` (additive members of `JsonEditorErrorCode`).
+
+No action is strictly required — a `translations` object doesn't have to be exhaustive, so any key you don't define falls back to the English default. But if you ship a localised `translations` object and want these two messages translated too, add the new keys:
+
+```diff
+  translations={{
+    // ...existing keys
+    ERROR_UPDATE: '…',
++   ERROR_RENAME: '…',
++   ERROR_MOVE: '…',
+  }}
+```
+
 ---
 ## 10. Observers reshaped: `onEditEvent` lifecycle stream; flat `onError` / `onCollapse`; `onCopy` error
 

--- a/src/JsonEditor.tsx
+++ b/src/JsonEditor.tsx
@@ -39,7 +39,7 @@ import {
   useEditingStore,
   useCollapse,
 } from './contexts'
-import { getTranslateFunction } from './localisation'
+import { getTranslateFunction, type LocalisedStrings } from './localisation'
 import { ValueNodeWrapper } from './ValueNodeWrapper'
 
 import './style.css'
@@ -51,6 +51,19 @@ const defaultJsonStringify = (
   data: JsonData,
   replacer?: (key: string, value: unknown) => unknown
 ) => JSON.stringify(data, replacer, 2)
+
+// The localisation key for a generic reject (`onUpdate` → `false`), per event,
+// so the message matches the `onError` code the node routes it to (`ADD_ERROR`,
+// `DELETE_ERROR`, `RENAME_ERROR`, `MOVE_ERROR`). `edit` uses `ERROR_UPDATE`,
+// which also covers internal failures (code `UPDATE_ERROR`). Typed as an
+// exhaustive `Record` over the event union so a new event can't slip through.
+const ERROR_MESSAGE_KEY: Record<UpdateFunctionProps['event'], keyof LocalisedStrings> = {
+  edit: 'ERROR_UPDATE',
+  add: 'ERROR_ADD',
+  delete: 'ERROR_DELETE',
+  rename: 'ERROR_RENAME',
+  move: 'ERROR_MOVE',
+}
 
 // Wrap an optional consumer callback so its identity stays STABLE across
 // renders (lets the React.memo'd nodes bail) while always invoking the LATEST
@@ -228,18 +241,12 @@ const Editor: React.FC<
       // display. No `setData` — nothing was committed (we only ever `setData`
       // AFTER `onUpdate` resolves), so writing `fullData` back would be a no-op
       // at best and, with a slow async `onUpdate`, could clobber a newer commit
-      // that landed while this one was in flight. The message is event-specific
-      // so it matches the `onError` code the node routes it to
-      // (`ADD_ERROR`/`DELETE_ERROR`); `rename`/`move` have no dedicated key, so
-      // they fall back to `ERROR_UPDATE` (their code is `UPDATE_ERROR`).
+      // that landed while this one was in flight. `ERROR_MESSAGE_KEY` picks the
+      // event-specific message so it matches the `onError` code the node routes
+      // it to (`ADD_ERROR`/`DELETE_ERROR`/`RENAME_ERROR`/`MOVE_ERROR`); `edit`
+      // (and internal failures) use `ERROR_UPDATE` / `UPDATE_ERROR`.
       if (result === false) {
-        const errorKey =
-          input.event === 'add'
-            ? 'ERROR_ADD'
-            : input.event === 'delete'
-            ? 'ERROR_DELETE'
-            : 'ERROR_UPDATE'
-        return translateRef.current(errorKey, rootNodeDataRef.current)
+        return translateRef.current(ERROR_MESSAGE_KEY[input.event], rootNodeDataRef.current)
       }
 
       // Silent cancel: no commit, no error — signal the node to revert its display

--- a/src/hooks/useCommon.ts
+++ b/src/hooks/useCommon.ts
@@ -210,7 +210,7 @@ export const useCommon = ({ props, collapsed }: CommonProps) => {
     onRename(path, newKey).then((result) =>
       handleMutationResult({
         result,
-        errorCode: 'UPDATE_ERROR',
+        errorCode: 'RENAME_ERROR',
         errorValue: newKey as ValueData,
         cancelEvent: 'cancelRename',
         confirmEvent: 'confirmRename',

--- a/src/hooks/useDragNDrop.tsx
+++ b/src/hooks/useDragNDrop.tsx
@@ -146,7 +146,7 @@ export const useDragNDrop = ({
     } else {
       onMove(dragSource.path, path, position).then((result) => {
         if (typeof result === 'string')
-          onError({ code: 'UPDATE_ERROR', message: result }, nodeData.value as CollectionData)
+          onError({ code: 'MOVE_ERROR', message: result }, nodeData.value as CollectionData)
         // `move` onEditEvent fires from the internal `onMove` handler (it owns
         // the SOURCE node's NodeData) — not here, where only the drop target is.
       })

--- a/src/localisation.ts
+++ b/src/localisation.ts
@@ -11,6 +11,8 @@ const localisedStrings = {
   ERROR_UPDATE: 'Update unsuccessful',
   ERROR_DELETE: 'Delete unsuccessful',
   ERROR_ADD: 'Adding node unsuccessful',
+  ERROR_RENAME: 'Rename unsuccessful',
+  ERROR_MOVE: 'Move unsuccessful',
   DEFAULT_STRING: 'New data!',
   DEFAULT_NEW_KEY: 'key',
   SHOW_LESS: '(Show less)',

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,6 +192,8 @@ export type JsonEditorErrorCode =
   | 'UPDATE_ERROR' // an edit was rejected, or an internal failure occurred
   | 'ADD_ERROR' // an add was rejected
   | 'DELETE_ERROR' // a delete was rejected
+  | 'RENAME_ERROR' // a key rename was rejected
+  | 'MOVE_ERROR' // a drag-and-drop move was rejected
   | 'KEY_EXISTS' // a new/renamed key collides with an existing sibling
   | 'INVALID_JSON' // raw JSON typed into the editor failed to parse
   | 'CLIPBOARD_ERROR' // a copy-to-clipboard write failed (onCopy)

--- a/test/JsonEditor.test.tsx
+++ b/test/JsonEditor.test.tsx
@@ -990,6 +990,32 @@ describe('JsonEditor — restrictions and callbacks', () => {
     expect(screen.getByText('Adding node unsuccessful')).toBeInTheDocument()
   })
 
+  test('onUpdate returning false on a rename shows the rename-specific message and code', async () => {
+    const user = userEvent.setup()
+    const onUpdate = jest.fn(() => false as const)
+    const onError = jest.fn()
+    render(
+      <JsonEditor data={{ oldName: 2 }} setData={noop} onUpdate={onUpdate} onError={onError} />
+    )
+
+    await user.dblClick(screen.getByText('oldName'))
+    const keyInput = screen.getByDisplayValue('oldName') as HTMLInputElement
+    await user.clear(keyInput)
+    await user.type(keyInput, 'newName{Enter}')
+
+    // Event-specific message...
+    expect(screen.getByText('Rename unsuccessful')).toBeInTheDocument()
+    // ...matching the RENAME_ERROR code routed to onError
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.objectContaining({ code: 'RENAME_ERROR' }) })
+    )
+  })
+
+  // A rejected move would surface 'Move unsuccessful' (code MOVE_ERROR), but
+  // exercising it needs a full drag-drop simulation — deferred with the rest of
+  // the DnD test gap (#270), like the move happy-path above.
+  test.todo('onUpdate returning false on a move shows the move-specific message (needs DnD — #270)')
+
   test('a rejected to-enum type change reverts the type selector (not stuck on the enum)', async () => {
     const user = userEvent.setup()
     const onUpdate = jest.fn(() => false as const)


### PR DESCRIPTION
Closes #308.

## Context

PR #303 made `handleEdit` surface an **event-specific** rejection message: a generic reject (`onUpdate` returning `false`) on an `add`/`delete` shows `ERROR_ADD` / `ERROR_DELETE` instead of the generic `ERROR_UPDATE`. The stated invariant (comment in `handleEdit`) is that *the message is event-specific so it matches the `onError` code the node routes it to.*

`rename` and `move` became first-class `onUpdate` events in #297 but were left out: they had **no dedicated localisation key** (a rejected rename/move showed "Update unsuccessful") and reused the generic `UPDATE_ERROR` code. `add`/`delete` already have both a dedicated message *and* code, so rename/move were the odd ones out.

## What this does

Gives rename/move full parity — dedicated messages **and** dedicated codes — restoring the message↔code coherence the `handleEdit` comment promises.

| Area | Change |
| --- | --- |
| `src/types.ts` | Add `RENAME_ERROR` / `MOVE_ERROR` to the public `JsonEditorErrorCode` union (additive) |
| `src/localisation.ts` | Add `ERROR_RENAME: 'Rename unsuccessful'` / `ERROR_MOVE: 'Move unsuccessful'` |
| `src/JsonEditor.tsx` | Replace the `errorKey` ternary in `handleEdit` with a module-scope `ERROR_MESSAGE_KEY` lookup typed `Record<UpdateFunctionProps['event'], keyof LocalisedStrings>` — exhaustive over the event union so a future event can't silently fall through |
| `src/hooks/useCommon.ts` | Rename emits `RENAME_ERROR` |
| `src/hooks/useDragNDrop.tsx` | Move emits `MOVE_ERROR` |
| `README.md` | Localisation table + `onError` code list |
| `test/JsonEditor.test.tsx` | Runnable rename-reject test (asserts both the message *and* the `RENAME_ERROR` code); move-reject as `test.todo` (DnD simulation deferred — #270) |

## Naming decisions

- **Error codes** follow the existing `<OP>_ERROR` suffix convention: `RENAME_ERROR` / `MOVE_ERROR` (consistent with `ADD_ERROR` / `DELETE_ERROR`).
- **Localisation keys** follow the existing `ERROR_<OP>` prefix convention: `ERROR_RENAME` / `ERROR_MOVE` (consistent with `ERROR_ADD` / `ERROR_DELETE`).

The two new codes are **additive** members of the public union — no internal exhaustive switch consumes it, so nothing breaks. A `minor` changeset is included.

## Verification

- `pnpm compile` ✅ — union extension typechecks, `keyof LocalisedStrings` picks up the new keys, no dead exports
- `pnpm lint` ✅ clean
- `pnpm test` ✅ 295 passed + 3 todo
- Regression-first check: temporarily reverted the rename code mapping → the new test failed with the right mode (`UPDATE_ERROR` instead of `RENAME_ERROR`), then restored and re-confirmed green

🤖 Generated with [Claude Code](https://claude.com/claude-code)