### PR TITLE
Add confirm-before-update hooks to @json-edit-react/utils (#307)

### DIFF
--- a/.changeset/utils-confirm-hooks.md
+++ b/.changeset/utils-confirm-hooks.md
@@ -1,0 +1,10 @@
+---
+'@json-edit-react/utils': minor
+---
+
+Add confirm-before-update hooks — the first helpers in `@json-edit-react/utils`.
+
+- **`useJsonEditorConfirm`** (primitive) — bridges an imperative `confirm()` to a render-driven modal via a deferred promise. Returns `confirm` (resolves `Promise<boolean>`) and a `dialog` state object to drive your own modal.
+- **`useConfirmOnUpdate`** (declarative wrapper) — for the common "ask before these events" case. Declare `confirmOn` (event-name array or predicate), optional `title`/`message` (static or per-input), and an optional inner `onUpdate`; get back a ready-made `onUpdate` plus the same `dialog`.
+
+Both build on core's async `onUpdate` contract (it `await`s the result and treats `null` as a silent cancel), so no modal UI ships with the library — you bring your own and wire it to `dialog`. Zero runtime dependencies; types-only import from `json-edit-react`.

--- a/.changeset/utils-confirm-hooks.md
+++ b/.changeset/utils-confirm-hooks.md
@@ -5,6 +5,7 @@
 Add confirm-before-update hooks — the first helpers in `@json-edit-react/utils`.
 
 - **`useJsonEditorConfirm`** (primitive) — bridges an imperative `confirm()` to a render-driven modal via a deferred promise. Returns `confirm` (resolves `Promise<boolean>`) and a `dialog` state object to drive your own modal.
-- **`useConfirmOnUpdate`** (declarative wrapper) — for the common "ask before these events" case. Declare `confirmOn` (event-name array or predicate), optional `title`/`message` (static or per-input), and an optional inner `onUpdate`; get back a ready-made `onUpdate` plus the same `dialog`.
+- **`useConfirmOnUpdate`** (declarative wrapper) — for the common "ask before these events" case. Declare `confirmOn` (event-name array or predicate), optional `title`/`message` (static or per-input), and an optional inner `onUpdate`; get back a ready-made `onUpdate` plus the same `dialog`. Also exposes `pending` (`{ path, event } | null`) — the node whose update is in flight.
+- **Pending-node overlay** (opt-in) — pass your own `pendingComponent` and `useConfirmOnUpdate` returns a ready `pendingNodeDefinition` to merge into `customNodeDefinitions` (or build it directly with `createPendingCommitDefinition`). Mainly useful when confirming _edits_; a _delete_-confirm doesn't need it.
 
-Both build on core's async `onUpdate` contract (it `await`s the result and treats `null` as a silent cancel), so no modal UI ships with the library — you bring your own and wire it to `dialog`. Zero runtime dependencies; types-only import from `json-edit-react`.
+The package ships **no UI** — you bring your own modal (driven by `dialog`) and, if you want it, your own pending-node component. Both hooks build on core's async `onUpdate` contract (it `await`s the result and treats `null` as a silent cancel). No third-party runtime dependencies.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A highly-configurable [React](https://github.com/facebook/react) component for e
 
 ## Contents  <!-- omit in toc -->
 - [Installation](#installation)
+  - [Optional companion packages](#optional-companion-packages)
 - [Implementation](#implementation)
 - [Usage](#usage)
 - [Props Reference](#props-reference)
@@ -56,6 +57,8 @@ A highly-configurable [React](https://github.com/facebook/react) component for e
   - [External control](#external-control)
   - [Miscellaneous](#miscellaneous)
 - [Managing State](#managing-state)
+  - [Viewer mode](#viewer-mode)
+  - [Typed data](#typed-data)
 - [Update Functions](#update-functions)
   - [OnChange Function](#onchange-function)
   - [OnError Function](#onerror-function)
@@ -85,7 +88,7 @@ A highly-configurable [React](https://github.com/facebook/react) component for e
 - [Keyboard customisation](#keyboard-customisation)
 - [External control](#external-control-1)
   - [Event callbacks](#event-callbacks)
-  - [Event triggers](#event-triggers)
+  - [Imperative handle (`editorRef`)](#imperative-handle-editorref)
 - [Undo functionality](#undo-functionality)
 - [Exported helpers](#exported-helpers)
   - [Functions \& Components](#functions--components)
@@ -176,15 +179,15 @@ This is a reference list of *all* possible props, divided into related sections.
 
 </summary>
 
-| Prop              | Type                    | Default | Description                                                                                                                         |
-| ----------------- | ----------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `data`            | `object\|array`         | none    | The data to be displayed / edited                                                                                                   |
-| `setData`         | `object\|array => void` | none    | Method to update your `data` object. **Required.** See [Managing state](#managing-state) below for additional notes.                |
-| `onUpdate`        | `UpdateFunction`        | none    | A function to run whenever a value is changed in the editor — edit, add, delete, rename *or* move. Branch on `event` to handle each. See [Update functions](#update-functions). |
-| `onChange`        | `OnChangeFunction`      | none    | A function to modify/constrain user input as they type — see [OnChange functions](#onchange-function).                              |
-| `onError`         | `OnErrorFunction`       | none    | A function to run whenever the component reports an error — see [OnErrorFunction](#onerror-function).                               |
-| `allowClipboard`  | `boolean`               | `true`  | Enable or disable the "Copy to clipboard" button in the UI.                                                                         |
-| `onCopy`          | `OnCopyFunction`        | none    | A function to run whenever an item is **copied** to the clipboard — see [Copy Function](#copy-function).                            |
+| Prop             | Type                    | Default | Description                                                                                                                                                                     |
+| ---------------- | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`           | `object\|array`         | none    | The data to be displayed / edited                                                                                                                                               |
+| `setData`        | `object\|array => void` | none    | Method to update your `data` object. **Required.** See [Managing state](#managing-state) below for additional notes.                                                            |
+| `onUpdate`       | `UpdateFunction`        | none    | A function to run whenever a value is changed in the editor — edit, add, delete, rename *or* move. Branch on `event` to handle each. See [Update functions](#update-functions). |
+| `onChange`       | `OnChangeFunction`      | none    | A function to modify/constrain user input as they type — see [OnChange functions](#onchange-function).                                                                          |
+| `onError`        | `OnErrorFunction`       | none    | A function to run whenever the component reports an error — see [OnErrorFunction](#onerror-function).                                                                           |
+| `allowClipboard` | `boolean`               | `true`  | Enable or disable the "Copy to clipboard" button in the UI.                                                                                                                     |
+| `onCopy`         | `OnCopyFunction`        | none    | A function to run whenever an item is **copied** to the clipboard — see [Copy Function](#copy-function).                                                                        |
 
 </details>
 <details>
@@ -194,15 +197,15 @@ This is a reference list of *all* possible props, divided into related sections.
 
 </summary>
 
-| Prop                    | Type                                      | Default | Description                                                                                                                                                             |
-| ----------------------- | ----------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `allowEdit`             | `boolean\|FilterFunction`                 | `true`  | If `false`, no editing at all is permitted. A callback function can be provided (return `true` to permit a given node) — see [Advanced Editing Control](#advanced-editing-control) |
-| `allowDelete`           | `boolean\|FilterFunction`                 | `true`  | As with `allowEdit` but for deletion                                                                                                                                    |
-| `allowAdd`              | `boolean\|FilterFunction`                 | `true`  | As with `allowEdit` but for adding new properties                                                                                                                       |
-| `allowTypeSelection`    | `boolean\|DataType[]\|TypeFilterFunction` | `true`  | Controls which data types the user can select, including [Custom Node](#custom-nodes) types, and **Enums** — see [Data Type Restrictions](#data-type-restrictions)      |
-| `newKeyOptions`         | `string[] \| NewKeyOptionsFunction`       | none    | New keys can be restricted to certain values — see [New Key Restrictions & Default Values](#new-key-restrictions--default-values)                                       |
-| `defaultValue`          | `any\|DefaultValueFilterFunction`         | `null`  | Value that new properties are initialised with — see [New Key Restrictions & Default Values](#new-key-restrictions--default-values)                                     |
-| `allowDrag`             | `boolean\|FilterFunction`                 | `false` | Set to `true` to enable drag and drop functionality — see [Drag-n-drop](#drag-n-drop)                                                                                   |
+| Prop                 | Type                                      | Default | Description                                                                                                                                                                        |
+| -------------------- | ----------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allowEdit`          | `boolean\|FilterFunction`                 | `true`  | If `false`, no editing at all is permitted. A callback function can be provided (return `true` to permit a given node) — see [Advanced Editing Control](#advanced-editing-control) |
+| `allowDelete`        | `boolean\|FilterFunction`                 | `true`  | As with `allowEdit` but for deletion                                                                                                                                               |
+| `allowAdd`           | `boolean\|FilterFunction`                 | `true`  | As with `allowEdit` but for adding new properties                                                                                                                                  |
+| `allowTypeSelection` | `boolean\|DataType[]\|TypeFilterFunction` | `true`  | Controls which data types the user can select, including [Custom Node](#custom-nodes) types, and **Enums** — see [Data Type Restrictions](#data-type-restrictions)                 |
+| `newKeyOptions`      | `string[] \| NewKeyOptionsFunction`       | none    | New keys can be restricted to certain values — see [New Key Restrictions & Default Values](#new-key-restrictions--default-values)                                                  |
+| `defaultValue`       | `any\|DefaultValueFilterFunction`         | `null`  | Value that new properties are initialised with — see [New Key Restrictions & Default Values](#new-key-restrictions--default-values)                                                |
+| `allowDrag`          | `boolean\|FilterFunction`                 | `false` | Set to `true` to enable drag and drop functionality — see [Drag-n-drop](#drag-n-drop)                                                                                              |
 
 </details>
 
@@ -223,7 +226,7 @@ This is a reference list of *all* possible props, divided into related sections.
 | `collapseClickZones`    | `Array<"left" \| "header" \| "property">` | `["left", "header"]` | Aside from the <span style="font-size: 140%">`⌄`</span> icon, you can specify other regions of the UI to be clickable for collapsing/opening a collection.                                                                                                                                                                                                                                                |
 | `rootName`              | `string`                                  | `"data"`             | A name to display in the editor as the root of the data object.                                                                                                                                                                                                                                                                                                                                           |
 | `showArrayIndexes`      | `boolean`                                 | `true`               | Whether or not to display the index (as a property key) for array elements.                                                                                                                                                                                                                                                                                                                               |
-| `arrayIndexStart`       | `0 \| 1`                                  | `0`                  | The number the *first* array element's index label starts from. `0` (default) gives `0, 1, 2…`; `1` gives `1, 2, 3…`.                                                                                                                                                                                                                                                                                      |
+| `arrayIndexStart`       | `0 \| 1`                                  | `0`                  | The number the *first* array element's index label starts from. `0` (default) gives `0, 1, 2…`; `1` gives `1, 2, 3…`.                                                                                                                                                                                                                                                                                     |
 | `showStringQuotes`      | `boolean`                                 | `true`               | Whether or not to display string values in "quotes".                                                                                                                                                                                                                                                                                                                                                      |
 | `showCollectionCount`   | `boolean\|"when-closed"`                  | `true`               | Whether or not to display the number of items in each collection (object or array).                                                                                                                                                                                                                                                                                                                       |
 | `stringTruncateLength`  | `number`                                  | `250`                | String values longer than this many characters will be displayed truncated (with `...`). The full string will always be visible when editing.                                                                                                                                                                                                                                                             |
@@ -274,11 +277,11 @@ This is a reference list of *all* possible props, divided into related sections.
 
 More detail [below](#external-control-1)
 
-| Prop               | Type                  | Default | Description                                                                                            |
-| ------------------ | --------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `onEditEvent`      | `OnEditEventFunction` | none    | Callback to execute whenever the user starts or stops editing a node                                   |
-| `onCollapse`       | `OnCollapseFunction`  | none    | Callback to execute whenever the user collapses or opens a node                                        |
-| `editorRef`        | `Ref<JsonEditorHandle>` | none  | Imperative handle to collapse/open nodes or start/stop editing. See [Imperative handle](#imperative-handle-editorref) |
+| Prop          | Type                    | Default | Description                                                                                                           |
+| ------------- | ----------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| `onEditEvent` | `OnEditEventFunction`   | none    | Callback to execute whenever the user starts or stops editing a node                                                  |
+| `onCollapse`  | `OnCollapseFunction`    | none    | Callback to execute whenever the user collapses or opens a node                                                       |
+| `editorRef`   | `Ref<JsonEditorHandle>` | none    | Imperative handle to collapse/open nodes or start/stop editing. See [Imperative handle](#imperative-handle-editorref) |
 
 </details>
 
@@ -1046,10 +1049,10 @@ Custom nodes are provided in the `customNodeDefinitions` prop, as an array of ob
 
 A definition can target two slots independently — the **key** slot (via `keyComponent`) and the **value/contents** slot (via `component`). Either or both. The same model applies uniformly to value nodes and collection nodes:
 
-| Slot                | Value node                                    | Collection node                                                    |
-| ------------------- | --------------------------------------------- | ------------------------------------------------------------------ |
-| Key                 | `keyComponent`                                   | `keyComponent`                                                        |
-| Value / contents    | `component`                                     | `component` (renders **between** the brackets)                       |
+| Slot                | Value node                                       | Collection node                                                      |
+| ------------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
+| Key                 | `keyComponent`                                   | `keyComponent`                                                       |
+| Value / contents    | `component`                                      | `component` (renders **between** the brackets)                       |
 | Whole-node override | `component` with `showKey: false` (escape hatch) | `wrapperComponent`, or `showCollectionWrapper: false` (escape hatch) |
 
 Most cases are best served by targeting the specific slot you want to change — e.g. for a clickable or highlighted key, use `keyComponent`; for an alternative value renderer (image, date picker, etc.), use `component`.

--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,9 @@ By default, your `component` is presented to the right of the property key it be
 
 If you want a single component to render the **entire row** (both key and value together — for example a tightly-coupled composite where the layout can't be decomposed into two slots), you can set `showKey: false` and let your `component` take the whole row. This is supported as an escape hatch; for most cases the `keyComponent` + `component` split is cleaner and preserves the standard key-editing UX.
 
+> [!IMPORTANT]
+> Keep your `customNodeDefinitions` array **referentially stable** — define it at module scope, or wrap it in `useMemo`. The editor compares this prop by reference to decide whether a node can skip re-rendering, so a brand-new inline array (`customNodeDefinitions={[...]}`) on every render forces every node to re-render every time, defeating the editor's fine-grained re-rendering. It still works correctly — just slower. The same guidance applies to your `condition` and other function/object props.
+
 ### Customising keys
 
 A `keyComponent` component is rendered in place of the default property label, in **view mode**. It receives the following props ([`CustomKeyProps`](https://github.com/CarlosNZ/json-edit-react/blob/main/src/types.ts)):

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -10,7 +10,13 @@ import {
   extract,
   isCollection,
   type JsonEditorHandle,
+  type UpdateFunctionProps,
 } from '@json-edit-react'
+// DEMO (Intro dataset): confirm-before-update via @json-edit-react/utils.
+// Comment out this import + the wiring below to disable. Swap the commented
+// import to demo the Layer-1 primitive instead.
+import { useConfirmOnUpdate /*, useJsonEditorConfirm */ } from '@json-edit-react/utils'
+import { ConfirmDialog } from './ConfirmDialog'
 import { FaNpm, FaExternalLinkAlt, FaGithub } from 'react-icons/fa'
 import { BiReset } from 'react-icons/bi'
 import { AiOutlineCloudUpload } from 'react-icons/ai'
@@ -179,6 +185,59 @@ function App() {
   const updateState = (patch: Partial<AppState>) => setState({ ...state, ...patch })
 
   const toggleState = (field: keyof AppState) => updateState({ [field]: !state[field] })
+
+  // §17: one `onUpdate`. The datasets' per-operation helpers (onEdit/onAdd) are
+  // dispatched by `event`, with `onUpdate` as the catch-all (delete/rename/move),
+  // followed by any post-commit demo side effect. Extracted to a named function
+  // so the confirm-hook demo below can wrap it.
+  const demoOnUpdate = async (nodeData: UpdateFunctionProps) => {
+    const runDemoUpdate = () => {
+      if (nodeData.event === 'edit' && dataDefinition?.onEdit)
+        return dataDefinition.onEdit(nodeData)
+      if (nodeData.event === 'add' && dataDefinition?.onAdd) return dataDefinition.onAdd(nodeData)
+      return (dataDefinition?.onUpdate ?? (() => undefined))(
+        nodeData,
+        toast as (options: unknown) => void
+      )
+    }
+    const result = await runDemoUpdate()
+    // Reject (false) or silent cancel (null): pass straight through, no commit
+    // and no post-commit side effect.
+    if (result === false || result === null) return result
+    // Object result (error / { value } override): pass through to the library.
+    // `true` is a plain commit — fall through to the side effect like void.
+    if (result && result !== true) return result
+    // Commit (true | void | undefined): run the post-commit demo side effect.
+    const { newData } = nodeData
+    if (selectedDataSet === 'editTheme') updateState({ theme: newData as Theme })
+  }
+
+  // ── DEMO: confirm-before-update on the Intro dataset (@json-edit-react/utils) ──
+  // To disable for production: comment this hook, the <ConfirmDialog/> render, and
+  // revert the editor's `onUpdate` prop to `demoOnUpdate`. Layer 2 (declarative)
+  // gates delete/edit and runs `demoOnUpdate` only after the user confirms.
+  const introConfirm = useConfirmOnUpdate({
+    confirmOn: ['delete', 'edit'],
+    title: 'Are you sure?',
+    message: (node) => {
+      const action = node.event[0].toUpperCase() + node.event.slice(1)
+      // Array items have a numeric key — name the item generically rather than
+      // quoting the index.
+      const target = typeof node.key === 'string' ? `"${node.key}"` : 'array item'
+      return `${action} ${target}?`
+    },
+    onUpdate: demoOnUpdate,
+  })
+  // Layer-1 equivalent (flip to this to demo the primitive instead): replace the
+  // hook above with `const introConfirm = useJsonEditorConfirm()` and gate at the
+  // top of `demoOnUpdate`:
+  //   if (selectedDataSet === 'intro' && (nodeData.event === 'delete' || nodeData.event === 'edit')) {
+  //     const action = nodeData.event[0].toUpperCase() + nodeData.event.slice(1)
+  //     const target = typeof nodeData.key === 'string' ? `"${nodeData.key}"` : 'array item'
+  //     const ok = await introConfirm.confirm({ title: 'Are you sure?', message: `${action} ${target}?` })
+  //     if (!ok) return null
+  //   }
+  // ───────────────────────────────────────────────────────────────────────────
 
   const {
     searchText,
@@ -491,32 +550,9 @@ function App() {
                   rootName={rootName}
                   theme={editorTheme}
                   indent={indent}
-                  onUpdate={async (nodeData) => {
-                    // §17: one `onUpdate`. The datasets' per-operation helpers
-                    // (onEdit/onAdd) are dispatched by `event`, with `onUpdate`
-                    // as the catch-all (delete/rename/move).
-                    const runDemoUpdate = () => {
-                      if (nodeData.event === 'edit' && dataDefinition?.onEdit)
-                        return dataDefinition.onEdit(nodeData)
-                      if (nodeData.event === 'add' && dataDefinition?.onAdd)
-                        return dataDefinition.onAdd(nodeData)
-                      return (dataDefinition?.onUpdate ?? (() => undefined))(
-                        nodeData,
-                        toast as (options: unknown) => void
-                      )
-                    }
-                    const result = await runDemoUpdate()
-                    // Reject (false) or silent cancel (null): pass straight
-                    // through, no commit and no post-commit side effect.
-                    if (result === false || result === null) return result
-                    // Object result (error / { value } override): pass through to
-                    // the library. `true` is a plain commit — fall through to the
-                    // side effect like void/undefined.
-                    if (result && result !== true) return result
-                    // Commit (true | void | undefined): run the post-commit demo side effect.
-                    const { newData } = nodeData
-                    if (selectedDataSet === 'editTheme') updateState({ theme: newData as Theme })
-                  }}
+                  // Intro dataset: gate via the confirm hook (which then runs
+                  // `demoOnUpdate`); every other dataset uses it directly.
+                  onUpdate={selectedDataSet === 'intro' ? introConfirm.onUpdate : demoOnUpdate}
                   onError={
                     dataDefinition.onError
                       ? (errorData) => {
@@ -692,6 +728,8 @@ function App() {
               </RenderProfiler>
             </Suspense>
           </Box>
+          {/* DEMO: confirm-before-update modal (Intro dataset). Comment out to disable. */}
+          <ConfirmDialog {...introConfirm.dialog} />
           <VStack w="100%" align="flex-end" gap={4}>
             <HStack w="100%" justify="space-between" mt={4}>
               <Button

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -17,6 +17,7 @@ import {
 // import to demo the Layer-1 primitive instead.
 import { useConfirmOnUpdate /*, useJsonEditorConfirm */ } from '@json-edit-react/utils'
 import { ConfirmDialog } from './ConfirmDialog'
+import { PendingCommit } from './PendingCommit'
 import { FaNpm, FaExternalLinkAlt, FaGithub } from 'react-icons/fa'
 import { BiReset } from 'react-icons/bi'
 import { AiOutlineCloudUpload } from 'react-icons/ai'
@@ -227,6 +228,10 @@ function App() {
       return `${action} ${target}?`
     },
     onUpdate: demoOnUpdate,
+    // Consumer-supplied pending overlay (the hooks ship no UI). Shows the
+    // affected node as "pending" while the modal is open — mainly useful here
+    // because we also confirm `edit`; a delete-only confirm wouldn't need it.
+    pendingComponent: PendingCommit,
   })
   // Layer-1 equivalent (flip to this to demo the primitive instead): replace the
   // hook above with `const introConfirm = useJsonEditorConfirm()` and gate at the
@@ -238,6 +243,17 @@ function App() {
   //     if (!ok) return null
   //   }
   // ───────────────────────────────────────────────────────────────────────────
+
+  // Merge the pending-overlay definition into the dataset's own custom nodes
+  // (kept referentially stable — see the CustomNodes docs). Guard on
+  // `pendingNodeDefinition`, which is undefined when no `pendingComponent` is set.
+  const introCustomNodeDefinitions = useMemo(
+    () =>
+      introConfirm.pendingNodeDefinition
+        ? [introConfirm.pendingNodeDefinition, ...(customNodeDefinitions ?? [])]
+        : customNodeDefinitions,
+    [introConfirm.pendingNodeDefinition, customNodeDefinitions]
+  )
 
   const {
     searchText,
@@ -625,7 +641,9 @@ function App() {
                   maxWidth="min(670px, 90vw)"
                   className="block-shadow"
                   stringTruncateLength={90}
-                  customNodeDefinitions={customNodeDefinitions}
+                  customNodeDefinitions={
+                    selectedDataSet === 'intro' ? introCustomNodeDefinitions : customNodeDefinitions
+                  }
                   // customNodeDefinitions={[
                   //   {
                   //     condition: ({ key }) => key === 'string',

--- a/demo/src/ConfirmDialog.tsx
+++ b/demo/src/ConfirmDialog.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react'
+import { WarningTwoIcon } from '@chakra-ui/icons'
+import type { ConfirmDialogState } from '@json-edit-react/utils'
+
+// Demo of "bring your own modal": the confirm hooks ship no UI — the `dialog`
+// object is the only contract. Here we drive a Chakra modal off it; any modal
+// library (or a plain div) wires up the same way.
+export const ConfirmDialog: React.FC<ConfirmDialogState> = (dialog) => (
+  <Modal isOpen={dialog.isOpen} onClose={dialog.onCancel} isCentered>
+    <ModalOverlay />
+    <ModalContent>
+      <ModalHeader display="flex" alignItems="center" gap={2}>
+        <WarningTwoIcon color="orange.400" />
+        {dialog.title ?? 'Are you sure?'}
+      </ModalHeader>
+      <ModalBody>{dialog.message}</ModalBody>
+      <ModalFooter gap={3}>
+        <Button variant="outline" colorScheme="blue" onClick={dialog.onCancel}>
+          Cancel
+        </Button>
+        <Button colorScheme="blue" onClick={dialog.onConfirm}>
+          OK
+        </Button>
+      </ModalFooter>
+    </ModalContent>
+  </Modal>
+)

--- a/demo/src/PendingCommit.tsx
+++ b/demo/src/PendingCommit.tsx
@@ -1,0 +1,14 @@
+import { type FC } from 'react'
+import { type CustomComponentProps } from '@json-edit-react'
+
+// Placeholder pending-overlay node for the confirm demo (Intro dataset). The
+// confirm hooks ship NO UI — the consumer supplies this and passes it as
+// `pendingComponent`. Just a red border for now; a proper visual comes later.
+export const PendingCommit: FC<CustomComponentProps> = ({ value, originalNode, componentProps }) => (
+  <div
+    title={`pending: ${String(componentProps?.event ?? '')}`}
+    style={{ border: '2px solid red', borderRadius: 4, padding: '0 0.25em' }}
+  >
+    {originalNode ?? <span>{String(value)}</span>}
+  </div>
+)

--- a/demo/tsconfig.app.json
+++ b/demo/tsconfig.app.json
@@ -20,6 +20,8 @@
       "@json-edit-react/themes/*": ["../packages/themes/src/*"],
       "@json-edit-react/components": ["../packages/components/src"],
       "@json-edit-react/components/*": ["../packages/components/src/*"],
+      "@json-edit-react/utils": ["../packages/utils/src"],
+      "@json-edit-react/utils/*": ["../packages/utils/src/*"],
       "@json-edit-react": ["../src/"],
       "@json-edit-react/*": ["../src/*"],
       // `@json-edit-react` is mapped to core's source (`../src`), which lives in

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -45,6 +45,13 @@ const componentsSrcMap: Record<PackageOption, string> = {
   pack: path.resolve(__dirname, '../pack-output/components/package'),
 }
 
+const utilsSrcMap: Record<PackageOption, string> = {
+  npm: '@json-edit-react/utils',
+  local: path.resolve(__dirname, '../packages/utils/src'),
+  build: path.resolve(__dirname, '../packages/utils/build/index.esm.js'),
+  pack: path.resolve(__dirname, '../pack-output/utils/package'),
+}
+
 const packageFile = coreSrcMap[provider].pkgJson
 const jsonEditReactPath = coreSrcMap[provider].src
 const pkg = fs.readJsonSync(packageFile)
@@ -86,6 +93,7 @@ export default defineConfig({
     alias: [
       { find: /^@json-edit-react\/themes$/, replacement: themesSrcMap[provider] },
       { find: /^@json-edit-react\/components$/, replacement: componentsSrcMap[provider] },
+      { find: /^@json-edit-react\/utils$/, replacement: utilsSrcMap[provider] },
       { find: /^@json-edit-react$/, replacement: jsonEditReactPath },
       { find: /^json-edit-react$/, replacement: jsonEditReactPath },
     ],

--- a/packages/utils/CLAUDE.md
+++ b/packages/utils/CLAUDE.md
@@ -66,7 +66,7 @@ Output: `build/index.cjs.js`, `build/index.esm.js`, `build/index.d.ts`.
 
 ## Adding a helper
 
-1. Create `src/<group>/` (`confirm`, `schema`, `search`) with the
+1. Create `src/<group>/` (`confirm-update`, `schema`, `search`) with the
    implementation and an `index.ts` barrel.
 2. Re-export it from [src/index.ts](src/index.ts).
 3. Check the dependency policy above — prefer zero runtime deps.

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -2,8 +2,7 @@
 
 Utility hooks and helpers for [json-edit-react](https://github.com/CarlosNZ/json-edit-react).
 
-> **Status: early/nascent.** This package is being assembled — the helpers below
-> are planned, not all shipped yet. See the linked issues for current state.
+> **Status: early/nascent.** This package is being assembled — the helpers below are planned, not all shipped yet. See the linked issues for current state.
 
 ## Install
 
@@ -19,29 +18,17 @@ pnpm add @json-edit-react/utils
 
 ## What's here
 
-- **Confirm-before-update hooks** — gate edits/deletes on a confirmation dialog
-  without hand-rolling the deferred-promise dance. _Available now._
-  ([#307](https://github.com/CarlosNZ/json-edit-react/issues/307))
-- **JSON Schema → Filter Functions** — generate `allowEdit` / `allowDelete` /
-  `allowAdd` (etc.) functions from a JSON Schema so the editor UI can't produce
-  invalid data in the first place. _Planned._
-  ([#285](https://github.com/CarlosNZ/json-edit-react/issues/285))
-- **Search helpers** — ready-made `searchFilter` functions for common search
-  patterns. _Planned._ ([#319](https://github.com/CarlosNZ/json-edit-react/issues/319))
+- **Confirm-before-update hooks** — gate edits/deletes on a confirmation dialog without hand-rolling the deferred-promise dance. _Available now._ ([#307](https://github.com/CarlosNZ/json-edit-react/issues/307))
+- **JSON Schema → Filter Functions** — generate `allowEdit` / `allowDelete` / `allowAdd` (etc.) functions from a JSON Schema so the editor UI can't produce invalid data in the first place. _Planned._ ([#285](https://github.com/CarlosNZ/json-edit-react/issues/285))
+- **Search helpers** — ready-made `searchFilter` functions for common search patterns. _Planned._ ([#319](https://github.com/CarlosNZ/json-edit-react/issues/319))
 
 ## Confirm before update
 
-`JsonEditor` `await`s your `onUpdate` before committing a change, and treats a
-returned `null` as a silent cancel. These hooks build on that: they let you hold
-an edit open until the user answers a confirmation dialog, then commit or revert
-based on the answer. **No modal ships with the library** — you bring your own (any
-modal component, or a plain `<div>`) and drive it from the returned `dialog`
-object.
+`JsonEditor` `await`s your `onUpdate` before committing a change, and treats a returned `null` as a silent cancel. These hooks build on that: they let you hold an edit open until the user answers a confirmation dialog, then commit or revert based on the answer. **No modal ships with the library** — you bring your own (any modal component, or a plain `<div>`) and drive it from the returned `dialog` object.
 
 ### `useConfirmOnUpdate` — the common case
 
-Declare _when_ to confirm and _what_ to say; you get back a ready-made `onUpdate`
-plus the `dialog` state for your modal:
+Declare _when_ to confirm and _what_ to say; you get back a ready-made `onUpdate` plus the `dialog` state for your modal:
 
 ```tsx
 import { JsonEditor } from 'json-edit-react'
@@ -69,8 +56,7 @@ const MyEditor = () => {
 
 ### `useJsonEditorConfirm` — the primitive
 
-When your gating is richer than "ask on these events," use the lower-level hook
-and write the `onUpdate` yourself. `confirm()` returns a `Promise<boolean>`:
+`useConfirmOnUpdate`'s `confirmOn` predicate already covers any _condition_, so reach for this lower-level hook for flows its single, synchronous confirm can't express: confirming based on `await`ed work, more than one confirmation in a single update, or reusing the dialog for actions outside `onUpdate`. You write the `onUpdate` yourself; `confirm()` returns a `Promise<boolean>`:
 
 ```tsx
 const { confirm, dialog } = useJsonEditorConfirm()
@@ -78,20 +64,46 @@ const { confirm, dialog } = useJsonEditorConfirm()
 <JsonEditor
   onUpdate={async (input) => {
     if (input.event === 'delete') {
-      const ok = await confirm({ title: 'Delete?', message: `Delete "${String(input.key)}"?` })
-      if (!ok) return null // null = silent cancel; the node reverts
+      // The decision to confirm — and the message — come from async work, which
+      // `useConfirmOnUpdate`'s synchronous `confirmOn`/`message` can't do.
+      const { inUse, usedBy } = await checkReferences(input.path)
+      if (inUse) {
+        const ok = await confirm({
+          title: 'Still in use',
+          message: `Referenced by ${usedBy.join(', ')}. Delete anyway?`,
+        })
+        if (!ok) return null // null = silent cancel; the node reverts
+      }
     }
-    // …any other custom logic, then fall through to commit
   }}
 />
 <MyModal {...dialog} />
 ```
 
+### Pending-node overlay (opt-in)
+
+Usually unnecessary: for a _delete_-confirm the node already shows the item until you confirm. Reach for this only when you confirm _edits_ (whose node would otherwise look already-applied) or run a slow async `onUpdate`. **The library ships no UI** — supply your own custom-node component as `pendingComponent`, and the hook returns a ready `pendingNodeDefinition`:
+
+```tsx
+const { onUpdate, dialog, pendingNodeDefinition } = useConfirmOnUpdate({
+  confirmOn: ['delete', 'edit'],
+  message,
+  pendingComponent: MyPendingNode,
+})
+
+const customNodeDefinitions = useMemo(
+  () => (pendingNodeDefinition ? [pendingNodeDefinition, ...myDefinitions] : myDefinitions),
+  [pendingNodeDefinition, myDefinitions]
+)
+
+<JsonEditor onUpdate={onUpdate} customNodeDefinitions={customNodeDefinitions} />
+```
+
+Omit `pendingComponent` and behaviour is unchanged. Keep `customNodeDefinitions` referentially stable (see the CustomNodes docs).
+
 ### Wiring your modal
 
-`dialog` is the only contract. Render your modal from it — `isOpen` controls
-visibility, `onConfirm` / `onCancel` are the button handlers, and `title` /
-`message` (plus any extra keys you pass to `confirm()`) carry the content:
+`dialog` is the only contract. Render your modal from it — `isOpen` controls visibility, `onConfirm` / `onCancel` are the button handlers, and `title` / `message` (plus any extra keys you pass to `confirm()`) carry the content:
 
 ```tsx
 const MyModal = (dialog) =>

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -20,23 +20,92 @@ pnpm add @json-edit-react/utils
 ## What's here
 
 - **Confirm-before-update hooks** — gate edits/deletes on a confirmation dialog
-  without hand-rolling the deferred-promise dance.
+  without hand-rolling the deferred-promise dance. _Available now._
   ([#307](https://github.com/CarlosNZ/json-edit-react/issues/307))
 - **JSON Schema → Filter Functions** — generate `allowEdit` / `allowDelete` /
   `allowAdd` (etc.) functions from a JSON Schema so the editor UI can't produce
-  invalid data in the first place.
+  invalid data in the first place. _Planned._
   ([#285](https://github.com/CarlosNZ/json-edit-react/issues/285))
 - **Search helpers** — ready-made `searchFilter` functions for common search
-  patterns. ([#319](https://github.com/CarlosNZ/json-edit-react/issues/319))
+  patterns. _Planned._ ([#319](https://github.com/CarlosNZ/json-edit-react/issues/319))
 
-## Usage
+## Confirm before update
+
+`JsonEditor` `await`s your `onUpdate` before committing a change, and treats a
+returned `null` as a silent cancel. These hooks build on that: they let you hold
+an edit open until the user answers a confirmation dialog, then commit or revert
+based on the answer. **No modal ships with the library** — you bring your own (any
+modal component, or a plain `<div>`) and drive it from the returned `dialog`
+object.
+
+### `useConfirmOnUpdate` — the common case
+
+Declare _when_ to confirm and _what_ to say; you get back a ready-made `onUpdate`
+plus the `dialog` state for your modal:
 
 ```tsx
 import { JsonEditor } from 'json-edit-react'
-// import { useConfirmOnUpdate } from '@json-edit-react/utils'
+import { useConfirmOnUpdate } from '@json-edit-react/utils'
+
+const MyEditor = () => {
+  const [data, setData] = useState(initialData)
+
+  const { onUpdate, dialog } = useConfirmOnUpdate({
+    confirmOn: ['delete', 'edit'], // event names, or a predicate: (input) => boolean
+    title: 'Please confirm',
+    message: (input) => `${input.event} "${String(input.key)}"?`,
+    // Optional: your own update logic, runs only after the user confirms
+    // onUpdate: async (input) => { /* … */ },
+  })
+
+  return (
+    <>
+      <JsonEditor data={data} setData={setData} onUpdate={onUpdate} />
+      <MyModal {...dialog} />
+    </>
+  )
+}
 ```
 
-(Usage examples will be filled in as each helper lands.)
+### `useJsonEditorConfirm` — the primitive
+
+When your gating is richer than "ask on these events," use the lower-level hook
+and write the `onUpdate` yourself. `confirm()` returns a `Promise<boolean>`:
+
+```tsx
+const { confirm, dialog } = useJsonEditorConfirm()
+
+<JsonEditor
+  onUpdate={async (input) => {
+    if (input.event === 'delete') {
+      const ok = await confirm({ title: 'Delete?', message: `Delete "${String(input.key)}"?` })
+      if (!ok) return null // null = silent cancel; the node reverts
+    }
+    // …any other custom logic, then fall through to commit
+  }}
+/>
+<MyModal {...dialog} />
+```
+
+### Wiring your modal
+
+`dialog` is the only contract. Render your modal from it — `isOpen` controls
+visibility, `onConfirm` / `onCancel` are the button handlers, and `title` /
+`message` (plus any extra keys you pass to `confirm()`) carry the content:
+
+```tsx
+const MyModal = (dialog) =>
+  dialog.isOpen ? (
+    <div className="backdrop" onClick={dialog.onCancel}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h2>{dialog.title}</h2>
+        <p>{dialog.message}</p>
+        <button onClick={dialog.onCancel}>Cancel</button>
+        <button onClick={dialog.onConfirm}>Confirm</button>
+      </div>
+    </div>
+  ) : null
+```
 
 ## License
 

--- a/packages/utils/src/_common/events.ts
+++ b/packages/utils/src/_common/events.ts
@@ -1,0 +1,9 @@
+import type { UpdateFunctionProps } from 'json-edit-react'
+
+/**
+ * The mutation events core can fire, derived from core's own contract so it
+ * can't drift. Shared vocabulary across utilities (e.g. the `confirmOn` array
+ * shorthand, or any helper that branches on the update event).
+ *   → 'edit' | 'add' | 'delete' | 'rename' | 'move'
+ */
+export type JsonEditorEventName = UpdateFunctionProps['event']

--- a/packages/utils/src/_common/pendingNode.ts
+++ b/packages/utils/src/_common/pendingNode.ts
@@ -1,0 +1,38 @@
+import { toPathString, type CustomNodeDefinition } from 'json-edit-react'
+import type { JsonEditorEventName } from './events'
+
+/**
+ * Identifies the node whose update is currently in flight (awaiting confirmation
+ * or a slow async `onUpdate`). `path` is a `toPathString` key for stable
+ * comparison; `event` lets a pending-node component branch its display. Shared
+ * by the confirm hooks and any other utility that overlays an in-flight node.
+ */
+export interface PendingUpdate {
+  path: string
+  event: JsonEditorEventName
+}
+
+/**
+ * Builds a `CustomNodeDefinition` that renders `component` on the node identified
+ * by `pending`. A factory (not a static const) because the `condition` closes
+ * over `pending` — and, just as importantly, the returned object's identity
+ * changes with `pending`, which is what makes the editor's memo comparator
+ * re-render the affected node (it compares `customNodeDefinitions` by reference).
+ *
+ * Takes the component as a parameter — this package ships no pending UI, and it
+ * keeps the module free of any component import so it never bloats consumers who
+ * don't use the overlay.
+ */
+export const createPendingCommitDefinition = (
+  pending: PendingUpdate | null,
+  component: NonNullable<CustomNodeDefinition['component']>
+): CustomNodeDefinition => ({
+  condition: ({ path }) => pending !== null && toPathString(path) === pending.path,
+  component,
+  componentProps: { event: pending?.event },
+  // The node is in VIEW mode during the pending window (core's `closeEdit` fires
+  // before the awaited commit), so render on view; lock its edit tools.
+  showOnView: true,
+  showEditTools: false,
+  passOriginalNode: true,
+})

--- a/packages/utils/src/confirm-update/README.md
+++ b/packages/utils/src/confirm-update/README.md
@@ -1,0 +1,86 @@
+# confirm-update
+
+Hooks (and an optional UI helper) for gating `json-edit-react` edits on a confirmation dialog — or any async signal — by building on core's async `onUpdate` contract. Exported from `@json-edit-react/utils`.
+
+`JsonEditor` `await`s `onUpdate` before committing and treats a returned `null` as a silent cancel, so an `onUpdate` that resolves only when the user answers a modal holds the edit open until they do. These helpers package that pattern.
+
+**No modal ships here** — you bring your own (any modal component, or a plain `<div>`) and drive it from the returned `dialog` object.
+
+## `useConfirmOnUpdate` — the common case
+
+Declare _when_ to confirm and _what_ to say; get back a ready-made `onUpdate` plus the `dialog` state for your modal.
+
+```tsx
+import { JsonEditor } from 'json-edit-react'
+import { useConfirmOnUpdate } from '@json-edit-react/utils'
+
+const { onUpdate, dialog } = useConfirmOnUpdate({
+  confirmOn: ['delete', 'edit'], // event names, or a predicate: (input) => boolean
+  title: 'Are you sure?',
+  message: (input) => `${input.event} "${String(input.key)}"?`,
+  // Optional: your own update logic, runs only after the user confirms
+  // onUpdate: async (input) => { /* … */ },
+})
+
+return (
+  <>
+    <JsonEditor data={data} setData={setData} onUpdate={onUpdate} />
+    <MyModal {...dialog} />
+  </>
+)
+```
+
+## `useJsonEditorConfirm` — the primitive
+
+`useConfirmOnUpdate`'s `confirmOn` predicate already covers any _condition_, so reach for this lower-level hook for flows its single, synchronous confirm can't express: confirming based on `await`ed work, more than one confirmation in a single update, or reusing the dialog for actions outside `onUpdate`. You write the `onUpdate` yourself; `confirm()` returns a `Promise<boolean>`.
+
+```tsx
+const { confirm, dialog } = useJsonEditorConfirm()
+
+<JsonEditor
+  onUpdate={async (input) => {
+    if (input.event === 'delete') {
+      // The decision to confirm — and the message — come from async work, which
+      // `useConfirmOnUpdate`'s synchronous `confirmOn`/`message` can't do.
+      const { inUse, usedBy } = await checkReferences(input.path)
+      if (inUse) {
+        const ok = await confirm({
+          title: 'Still in use',
+          message: `Referenced by ${usedBy.join(', ')}. Delete anyway?`,
+        })
+        if (!ok) return null // null = silent cancel; the node reverts
+      }
+    }
+  }}
+/>
+<MyModal {...dialog} />
+```
+
+## Pending-node overlay (opt-in)
+
+**You usually don't need this.** For the common _delete_-confirm, the node already sits there showing the item until you confirm — nothing misleading to mask. It's only worth it when you confirm _edits_ (whose node would otherwise show the new value as if already applied) or run a slow async `onUpdate`.
+
+When you do want it: **the library ships no UI** — supply your own custom-node component as `pendingComponent`, and the hook hands back a ready `pendingNodeDefinition` to merge into `customNodeDefinitions`.
+
+```tsx
+const { onUpdate, dialog, pendingNodeDefinition } = useConfirmOnUpdate({
+  confirmOn: ['delete', 'edit'],
+  message,
+  pendingComponent: MyPendingNode, // your custom-node component (renders the in-flight node)
+})
+
+// Guard the undefined case, and keep the array referentially stable (see the
+// CustomNodes docs) — that's what lets the editor re-render the right node.
+const customNodeDefinitions = useMemo(
+  () => (pendingNodeDefinition ? [pendingNodeDefinition, ...myDefinitions] : myDefinitions),
+  [pendingNodeDefinition, myDefinitions]
+)
+
+<JsonEditor onUpdate={onUpdate} customNodeDefinitions={customNodeDefinitions} />
+```
+
+Omit `pendingComponent` and `pendingNodeDefinition` is `undefined` — behaviour is unchanged (the node renders as it normally would). For full control, the hook also returns the raw `pending` (`{ path, event } | null`), and `createPendingCommitDefinition(pending, component)` builds the definition directly.
+
+## Wiring your modal
+
+`dialog` is the only contract: `isOpen` controls visibility, `onConfirm` / `onCancel` are the button handlers, and `title` / `message` (plus any extra keys you pass to `confirm()`) carry the content.

--- a/packages/utils/src/confirm-update/index.ts
+++ b/packages/utils/src/confirm-update/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './useJsonEditorConfirm'
+export * from './useConfirmOnUpdate'

--- a/packages/utils/src/confirm-update/types.ts
+++ b/packages/utils/src/confirm-update/types.ts
@@ -1,0 +1,63 @@
+import type { JsonData, UpdateFunction, UpdateFunctionProps } from 'json-edit-react'
+
+/**
+ * The mutation events core can fire, derived from core's own contract so it
+ * can't drift. This is the vocabulary for the `confirmOn` array shorthand.
+ *   → 'edit' | 'add' | 'delete' | 'rename' | 'move'
+ */
+export type JsonEditorEventName = UpdateFunctionProps['event']
+
+/**
+ * What the consumer passes to `confirm()`. `title`/`message` are conventional
+ * and stay type-checked, but any extra keys are accepted as an opaque payload
+ * (typed `unknown`) that the consumer's modal can read off the dialog state.
+ */
+export interface ConfirmRequest {
+  title?: string
+  message?: string
+  [key: string]: unknown
+}
+
+/**
+ * The reactive state the consumer drives their own modal from. Identity is
+ * stable while closed (a shared `CLOSED` constant); a fresh object each time
+ * `confirm()` opens it.
+ */
+export type ConfirmDialogState = ConfirmRequest & {
+  isOpen: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export interface UseJsonEditorConfirmResult {
+  /** Imperatively ask; resolves `true` (confirmed) / `false` (cancelled). */
+  confirm: (request?: ConfirmRequest) => Promise<boolean>
+  /** Render-time dialog state for the consumer's modal. */
+  dialog: ConfirmDialogState
+}
+
+/** A static string, or a function of the update input → string. */
+export type ConfirmMessage<T = JsonData> = string | ((input: UpdateFunctionProps<T>) => string)
+
+/** When to confirm: a list of event names, or a predicate over the update input. */
+export type ConfirmOn<T = JsonData> =
+  | JsonEditorEventName[]
+  | ((input: UpdateFunctionProps<T>) => boolean)
+
+export interface UseConfirmOnUpdateOptions<T = JsonData> {
+  /** Gate which updates require confirmation — required (nothing to gate without it). */
+  confirmOn: ConfirmOn<T>
+  /** Modal message (static, or built per-input). */
+  message?: ConfirmMessage<T>
+  /** Modal title (static, or built per-input). */
+  title?: ConfirmMessage<T>
+  /** Your own update logic — runs only after a confirm (or when `confirmOn` didn't match). */
+  onUpdate?: UpdateFunction<T>
+}
+
+export interface UseConfirmOnUpdateResult<T = JsonData> {
+  /** Ready-made handler to pass to `<JsonEditor onUpdate={...} />`. */
+  onUpdate: UpdateFunction<T>
+  /** Render-time dialog state for the consumer's modal. */
+  dialog: ConfirmDialogState
+}

--- a/packages/utils/src/confirm-update/types.ts
+++ b/packages/utils/src/confirm-update/types.ts
@@ -1,11 +1,11 @@
-import type { JsonData, UpdateFunction, UpdateFunctionProps } from 'json-edit-react'
-
-/**
- * The mutation events core can fire, derived from core's own contract so it
- * can't drift. This is the vocabulary for the `confirmOn` array shorthand.
- *   → 'edit' | 'add' | 'delete' | 'rename' | 'move'
- */
-export type JsonEditorEventName = UpdateFunctionProps['event']
+import type {
+  CustomNodeDefinition,
+  JsonData,
+  UpdateFunction,
+  UpdateFunctionProps,
+} from 'json-edit-react'
+import type { JsonEditorEventName } from '../_common/events'
+import type { PendingUpdate } from '../_common/pendingNode'
 
 /**
  * What the consumer passes to `confirm()`. `title`/`message` are conventional
@@ -53,6 +53,17 @@ export interface UseConfirmOnUpdateOptions<T = JsonData> {
   title?: ConfirmMessage<T>
   /** Your own update logic — runs only after a confirm (or when `confirmOn` didn't match). */
   onUpdate?: UpdateFunction<T>
+  /**
+   * Optional custom-node component that renders the in-flight node as a "pending"
+   * overlay while a confirm/async `onUpdate` is outstanding. Supply your own — the
+   * library ships no UI. When given, the hook returns a ready `pendingNodeDefinition`.
+   *
+   * You usually only need this when confirming **edits** (whose node would otherwise
+   * show the new value as if already applied) or running a slow async `onUpdate`. For
+   * the common **delete**-confirm case you can omit it: the node already sits there
+   * showing the item until you confirm.
+   */
+  pendingComponent?: NonNullable<CustomNodeDefinition['component']>
 }
 
 export interface UseConfirmOnUpdateResult<T = JsonData> {
@@ -60,4 +71,23 @@ export interface UseConfirmOnUpdateResult<T = JsonData> {
   onUpdate: UpdateFunction<T>
   /** Render-time dialog state for the consumer's modal. */
   dialog: ConfirmDialogState
+  /**
+   * The node whose update is in flight (set while awaiting confirmation or a
+   * slow async `onUpdate`, `null` otherwise). Exposed for custom pending UI; if
+   * you pass `pendingComponent`, prefer the ready-made `pendingNodeDefinition`.
+   */
+  pending: PendingUpdate | null
+  /**
+   * A memoized custom-node definition wiring `pendingComponent` to the in-flight
+   * node, or `undefined` when no `pendingComponent` was supplied. Merge it into
+   * your `customNodeDefinitions` (keeping that array referentially stable):
+   *
+   * ```tsx
+   * const defs = useMemo(
+   *   () => (pendingNodeDefinition ? [pendingNodeDefinition, ...mine] : mine),
+   *   [pendingNodeDefinition, mine]
+   * )
+   * ```
+   */
+  pendingNodeDefinition?: CustomNodeDefinition
 }

--- a/packages/utils/src/confirm-update/useConfirmOnUpdate.ts
+++ b/packages/utils/src/confirm-update/useConfirmOnUpdate.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react'
+import type { JsonData, UpdateFunction, UpdateFunctionProps } from 'json-edit-react'
+import { useJsonEditorConfirm } from './useJsonEditorConfirm'
+import type { ConfirmMessage, UseConfirmOnUpdateOptions, UseConfirmOnUpdateResult } from './types'
+
+const resolveMessage = <T,>(message: ConfirmMessage<T> | undefined, input: UpdateFunctionProps<T>) =>
+  typeof message === 'function' ? message(input) : message
+
+/**
+ * The declarative wrapper (Layer 2), built on {@link useJsonEditorConfirm}. For
+ * the common case — "ask before these events" — it pre-writes the
+ * branch → await confirm → `return null` on cancel boilerplate, handing back a
+ * ready-made `onUpdate` plus the same `dialog` to drive the consumer's modal.
+ *
+ * The returned `onUpdate`'s identity changes when options are passed inline, but
+ * core reads `onUpdate` through a ref, so that churn is harmless — consumers
+ * needn't memoize their options.
+ */
+export const useConfirmOnUpdate = <T = JsonData,>(
+  opts: UseConfirmOnUpdateOptions<T>
+): UseConfirmOnUpdateResult<T> => {
+  const { confirm, dialog } = useJsonEditorConfirm()
+  const { confirmOn, message, title, onUpdate: inner } = opts
+
+  const onUpdate: UpdateFunction<T> = useCallback(
+    async (input) => {
+      const shouldConfirm = Array.isArray(confirmOn)
+        ? confirmOn.includes(input.event)
+        : confirmOn(input)
+      if (shouldConfirm) {
+        const ok = await confirm({
+          title: resolveMessage(title, input),
+          message: resolveMessage(message, input),
+        })
+        if (!ok) return null
+      }
+      return inner ? inner(input) : undefined
+    },
+    [confirm, confirmOn, message, title, inner]
+  )
+
+  return { onUpdate, dialog }
+}

--- a/packages/utils/src/confirm-update/useConfirmOnUpdate.ts
+++ b/packages/utils/src/confirm-update/useConfirmOnUpdate.ts
@@ -1,6 +1,8 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { toPathString } from 'json-edit-react'
 import type { JsonData, UpdateFunction, UpdateFunctionProps } from 'json-edit-react'
 import { useJsonEditorConfirm } from './useJsonEditorConfirm'
+import { createPendingCommitDefinition, type PendingUpdate } from '../_common/pendingNode'
 import type { ConfirmMessage, UseConfirmOnUpdateOptions, UseConfirmOnUpdateResult } from './types'
 
 const resolveMessage = <T,>(message: ConfirmMessage<T> | undefined, input: UpdateFunctionProps<T>) =>
@@ -20,24 +22,44 @@ export const useConfirmOnUpdate = <T = JsonData,>(
   opts: UseConfirmOnUpdateOptions<T>
 ): UseConfirmOnUpdateResult<T> => {
   const { confirm, dialog } = useJsonEditorConfirm()
-  const { confirmOn, message, title, onUpdate: inner } = opts
+  const { confirmOn, message, title, onUpdate: inner, pendingComponent } = opts
+
+  // The node whose update is in flight. Set at the start of every update and
+  // cleared in `finally`, so it spans both the confirm dialog and a slow inner
+  // `onUpdate`. The synchronous, non-confirmed path sets + clears with no `await`
+  // between, so React batches it to a no-op (no flicker).
+  const [pending, setPending] = useState<PendingUpdate | null>(null)
+
+  // Build the pending-overlay definition only when the consumer supplies a UI
+  // component (the library ships none). Memoized on `[pending, pendingComponent]`
+  // so its identity changes exactly when `pending` does — the editor's memo
+  // comparator needs that to re-render the affected node.
+  const pendingNodeDefinition = useMemo(
+    () => (pendingComponent ? createPendingCommitDefinition(pending, pendingComponent) : undefined),
+    [pending, pendingComponent]
+  )
 
   const onUpdate: UpdateFunction<T> = useCallback(
     async (input) => {
-      const shouldConfirm = Array.isArray(confirmOn)
-        ? confirmOn.includes(input.event)
-        : confirmOn(input)
-      if (shouldConfirm) {
-        const ok = await confirm({
-          title: resolveMessage(title, input),
-          message: resolveMessage(message, input),
-        })
-        if (!ok) return null
+      setPending({ path: toPathString(input.path), event: input.event })
+      try {
+        const shouldConfirm = Array.isArray(confirmOn)
+          ? confirmOn.includes(input.event)
+          : confirmOn(input)
+        if (shouldConfirm) {
+          const ok = await confirm({
+            title: resolveMessage(title, input),
+            message: resolveMessage(message, input),
+          })
+          if (!ok) return null
+        }
+        return inner ? inner(input) : undefined
+      } finally {
+        setPending(null)
       }
-      return inner ? inner(input) : undefined
     },
     [confirm, confirmOn, message, title, inner]
   )
 
-  return { onUpdate, dialog }
+  return { onUpdate, dialog, pending, pendingNodeDefinition }
 }

--- a/packages/utils/src/confirm-update/useJsonEditorConfirm.ts
+++ b/packages/utils/src/confirm-update/useJsonEditorConfirm.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { ConfirmDialogState, ConfirmRequest, UseJsonEditorConfirmResult } from './types'
+
+// Shared closed state — a stable identity so a closed dialog never churns.
+const CLOSED: ConfirmDialogState = { isOpen: false, onConfirm: () => {}, onCancel: () => {} }
+
+/**
+ * The primitive (Layer 1): bridges an imperative "ask the user" to a
+ * render-driven modal via a deferred promise.
+ *
+ * Core already `await`s `onUpdate` before committing and treats a `null` result
+ * as a silent cancel, so an `onUpdate` that `await`s `confirm()` and returns
+ * `null` when it resolves `false` gates the edit on the user's answer. The
+ * promise's `resolve` is stashed in a ref (never state — resolving must not
+ * depend on a render) and called from the modal's button handlers.
+ *
+ * The consumer brings their own modal and drives it from the returned `dialog`.
+ */
+export const useJsonEditorConfirm = (): UseJsonEditorConfirmResult => {
+  const [dialog, setDialog] = useState<ConfirmDialogState>(CLOSED)
+  const pendingRef = useRef<((ok: boolean) => void) | null>(null)
+
+  const close = useCallback((ok: boolean) => {
+    pendingRef.current?.(ok)
+    pendingRef.current = null
+    setDialog(CLOSED)
+  }, [])
+
+  const confirm = useCallback(
+    (request: ConfirmRequest = {}) =>
+      new Promise<boolean>((resolve) => {
+        // Single-dialog model: supersede any still-open prompt by cancelling it.
+        pendingRef.current?.(false)
+        pendingRef.current = resolve
+        setDialog({
+          ...request,
+          isOpen: true,
+          onConfirm: () => close(true),
+          onCancel: () => close(false),
+        })
+      }),
+    [close]
+  )
+
+  // Unmount safety: resolve a dangling promise as cancelled so an awaiting
+  // `onUpdate` doesn't hang forever. No `setState` here — the component is gone.
+  useEffect(
+    () => () => {
+      pendingRef.current?.(false)
+      pendingRef.current = null
+    },
+    []
+  )
+
+  return { confirm, dialog }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -4,17 +4,13 @@
 // don't belong in the zero-dependency core. Keep this package free of runtime
 // dependencies wherever possible (see CLAUDE.md for the dependency policy).
 //
-// Planned contents (re-export each group from here as it lands):
+// Contents (re-export each group from here as it lands):
 //
 //   - Confirm-before-update hooks   — useJsonEditorConfirm / useConfirmOnUpdate
 //                                     https://github.com/CarlosNZ/json-edit-react/issues/307
-//   - JSON Schema → Filter Functions generator
+//   - JSON Schema → Filter Functions generator [planned]
 //                                     https://github.com/CarlosNZ/json-edit-react/issues/285
-//   - Ready-made `searchFilter` helpers for common search use cases
+//   - Ready-made `searchFilter` helpers for common search use cases [planned]
 //                                     https://github.com/CarlosNZ/json-edit-react/issues/319
-//
-// e.g.  export * from './confirm'
-//       export * from './schema'
-//       export * from './search'
 
-export {}
+export * from './confirm-update'

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,4 +13,9 @@
 //   - Ready-made `searchFilter` helpers for common search use cases [planned]
 //                                     https://github.com/CarlosNZ/json-edit-react/issues/319
 
+// Cross-utility shared pieces (event-name vocabulary, the in-flight pending-node
+// mechanism). Internal `_common`, surfaced here as public API.
+export * from './_common/events'
+export * from './_common/pendingNode'
+
 export * from './confirm-update'

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -4,7 +4,7 @@
     "jsx": "react-jsx",
     "declaration": true,
     "declarationDir": "build/dts",
-    "lib": ["dom", "es6"],
+    "lib": ["dom", "es2020"],
     "esModuleInterop": true,
     "outDir": "build",
     "rootDir": "src",

--- a/test/confirm.test.tsx
+++ b/test/confirm.test.tsx
@@ -1,9 +1,14 @@
 import { act, renderHook } from '@testing-library/react'
-import type { JsonData, UpdateFunctionProps } from '../src'
+import { toPathString } from '../src'
+import type { CustomNodeDefinition, JsonData, UpdateFunctionProps } from '../src'
 import {
+  createPendingCommitDefinition,
   useConfirmOnUpdate,
   useJsonEditorConfirm,
-} from '../packages/utils/src/confirm-update'
+} from '../packages/utils/src'
+
+// A throwaway custom-node component for definition tests.
+const PendingStub: NonNullable<CustomNodeDefinition['component']> = () => null
 
 // Minimal synthetic update input. The discriminated union's per-event extras
 // (newValue / newKey / newPath) are irrelevant to the gating logic, so a cast
@@ -194,5 +199,120 @@ describe('useConfirmOnUpdate (Layer 2)', () => {
 
     expect(result.current.dialog.title).toBe('Confirm')
     expect(result.current.dialog.message).toBe('delete "widget"?')
+  })
+})
+
+describe('useConfirmOnUpdate — pending lifecycle', () => {
+  it('exposes the pending node while a gated update awaits, then clears it on confirm', async () => {
+    const { result } = renderHook(() =>
+      useConfirmOnUpdate<JsonData>({ confirmOn: ['delete'], message: 'sure?' })
+    )
+    expect(result.current.pending).toBeNull()
+
+    let res!: Promise<unknown>
+    act(() => {
+      res = Promise.resolve(result.current.onUpdate(makeInput('delete', { path: ['a', 'b'] })))
+    })
+
+    expect(result.current.dialog.isOpen).toBe(true)
+    expect(result.current.pending).toEqual({ path: toPathString(['a', 'b']), event: 'delete' })
+
+    act(() => result.current.dialog.onConfirm())
+    await act(async () => {
+      await res
+    })
+    expect(result.current.pending).toBeNull()
+  })
+
+  it('clears pending on cancel', async () => {
+    const { result } = renderHook(() =>
+      useConfirmOnUpdate<JsonData>({ confirmOn: ['delete'], message: 'sure?' })
+    )
+
+    let res!: Promise<unknown>
+    act(() => {
+      res = Promise.resolve(result.current.onUpdate(makeInput('delete')))
+    })
+    expect(result.current.pending).not.toBeNull()
+
+    act(() => result.current.dialog.onCancel())
+    await act(async () => {
+      await res
+    })
+    expect(result.current.pending).toBeNull()
+  })
+
+  it('leaves pending null for a non-gated synchronous update', async () => {
+    const { result } = renderHook(() => useConfirmOnUpdate<JsonData>({ confirmOn: ['delete'] }))
+
+    let res!: Promise<unknown>
+    act(() => {
+      res = Promise.resolve(result.current.onUpdate(makeInput('edit')))
+    })
+    await act(async () => {
+      await res
+    })
+    expect(result.current.pending).toBeNull()
+  })
+})
+
+describe('createPendingCommitDefinition', () => {
+  it('matches the pending path, carries the event, and locks the node', () => {
+    const def = createPendingCommitDefinition(
+      { path: toPathString(['a', 'b']), event: 'delete' },
+      PendingStub
+    )
+    expect(def.condition(makeInput('delete', { path: ['a', 'b'] }))).toBe(true)
+    expect(def.condition(makeInput('delete', { path: ['a', 'c'] }))).toBe(false)
+    expect(def.component).toBe(PendingStub)
+    expect(def.componentProps).toEqual({ event: 'delete' })
+    expect(def.showOnView).toBe(true)
+    expect(def.showEditTools).toBe(false)
+    expect(def.passOriginalNode).toBe(true)
+  })
+
+  it('never matches when pending is null', () => {
+    const def = createPendingCommitDefinition(null, PendingStub)
+    expect(def.condition(makeInput('delete'))).toBe(false)
+  })
+})
+
+describe('useConfirmOnUpdate — pendingNodeDefinition', () => {
+  it('returns no pendingNodeDefinition without a pendingComponent', () => {
+    const { result } = renderHook(() => useConfirmOnUpdate<JsonData>({ confirmOn: ['delete'] }))
+    expect(result.current.pendingNodeDefinition).toBeUndefined()
+  })
+
+  it('builds a definition that matches the in-flight node once an update starts', async () => {
+    const { result } = renderHook(() =>
+      useConfirmOnUpdate<JsonData>({ confirmOn: ['delete'], pendingComponent: PendingStub })
+    )
+    // Defined, but matches nothing while idle (pending is null).
+    const idle = result.current.pendingNodeDefinition
+    expect(idle).toBeDefined()
+    expect(idle!.condition(makeInput('delete', { path: ['a'] }))).toBe(false)
+    expect(idle!.component).toBe(PendingStub)
+
+    let res!: Promise<unknown>
+    act(() => {
+      res = Promise.resolve(result.current.onUpdate(makeInput('delete', { path: ['a'] })))
+    })
+
+    // New identity (memo keyed on pending), now matching the in-flight node.
+    expect(result.current.pendingNodeDefinition).not.toBe(idle)
+    expect(result.current.pendingNodeDefinition!.condition(makeInput('delete', { path: ['a'] }))).toBe(
+      true
+    )
+    expect(result.current.pendingNodeDefinition!.condition(makeInput('delete', { path: ['b'] }))).toBe(
+      false
+    )
+
+    act(() => result.current.dialog.onConfirm())
+    await act(async () => {
+      await res
+    })
+    expect(result.current.pendingNodeDefinition!.condition(makeInput('delete', { path: ['a'] }))).toBe(
+      false
+    )
   })
 })

--- a/test/confirm.test.tsx
+++ b/test/confirm.test.tsx
@@ -1,0 +1,198 @@
+import { act, renderHook } from '@testing-library/react'
+import type { JsonData, UpdateFunctionProps } from '../src'
+import {
+  useConfirmOnUpdate,
+  useJsonEditorConfirm,
+} from '../packages/utils/src/confirm-update'
+
+// Minimal synthetic update input. The discriminated union's per-event extras
+// (newValue / newKey / newPath) are irrelevant to the gating logic, so a cast
+// keeps the helper terse.
+const makeInput = (
+  event: UpdateFunctionProps['event'],
+  overrides: Partial<UpdateFunctionProps> = {}
+): UpdateFunctionProps =>
+  ({
+    key: 'foo',
+    path: ['foo'],
+    level: 1,
+    index: 0,
+    value: 'bar',
+    size: null,
+    parentData: {},
+    fullData: {},
+    newData: {},
+    event,
+    ...overrides,
+  }) as UpdateFunctionProps
+
+describe('useJsonEditorConfirm (Layer 1)', () => {
+  it('opens the dialog with the supplied request and resolves true on confirm', async () => {
+    const { result } = renderHook(() => useJsonEditorConfirm())
+
+    expect(result.current.dialog.isOpen).toBe(false)
+
+    let pending!: Promise<boolean>
+    act(() => {
+      pending = result.current.confirm({ title: 'Delete?', message: 'Really delete "foo"?' })
+    })
+
+    expect(result.current.dialog.isOpen).toBe(true)
+    expect(result.current.dialog.title).toBe('Delete?')
+    expect(result.current.dialog.message).toBe('Really delete "foo"?')
+
+    act(() => result.current.dialog.onConfirm())
+
+    await expect(pending).resolves.toBe(true)
+    expect(result.current.dialog.isOpen).toBe(false)
+  })
+
+  it('resolves false on cancel', async () => {
+    const { result } = renderHook(() => useJsonEditorConfirm())
+
+    let pending!: Promise<boolean>
+    act(() => {
+      pending = result.current.confirm()
+    })
+
+    act(() => result.current.dialog.onCancel())
+
+    await expect(pending).resolves.toBe(false)
+    expect(result.current.dialog.isOpen).toBe(false)
+  })
+
+  it('carries opaque extra payload through to the dialog state', () => {
+    const { result } = renderHook(() => useJsonEditorConfirm())
+
+    act(() => {
+      void result.current.confirm({ message: 'x', severity: 'danger', count: 3 })
+    })
+
+    expect(result.current.dialog.severity).toBe('danger')
+    expect(result.current.dialog.count).toBe(3)
+  })
+
+  it('supersedes a still-open prompt, cancelling the first (single-dialog model)', async () => {
+    const { result } = renderHook(() => useJsonEditorConfirm())
+
+    let first!: Promise<boolean>
+    let second!: Promise<boolean>
+    act(() => {
+      first = result.current.confirm({ title: 'first' })
+    })
+    act(() => {
+      second = result.current.confirm({ title: 'second' })
+    })
+
+    await expect(first).resolves.toBe(false)
+    expect(result.current.dialog.title).toBe('second')
+
+    act(() => result.current.dialog.onConfirm())
+    await expect(second).resolves.toBe(true)
+  })
+
+  it('resolves a pending promise as false on unmount (no hanging await)', async () => {
+    const { result, unmount } = renderHook(() => useJsonEditorConfirm())
+
+    let pending!: Promise<boolean>
+    act(() => {
+      pending = result.current.confirm()
+    })
+
+    unmount()
+
+    await expect(pending).resolves.toBe(false)
+  })
+})
+
+describe('useConfirmOnUpdate (Layer 2)', () => {
+  it('returns null when the user cancels a gated event', async () => {
+    const { result } = renderHook(() =>
+      useConfirmOnUpdate<JsonData>({ confirmOn: ['delete'], message: 'sure?' })
+    )
+
+    let res!: Promise<unknown>
+    act(() => {
+      res = Promise.resolve(result.current.onUpdate(makeInput('delete')))
+    })
+
+    expect(result.current.dialog.isOpen).toBe(true)
+    expect(result.current.dialog.message).toBe('sure?')
+
+    act(() => result.current.dialog.onCancel())
+
+    await expect(res).resolves.toBeNull()
+  })
+
+  it('runs the inner onUpdate (and returns its result) on confirm', async () => {
+    const inner = jest.fn(() => ({ value: 'committed' }))
+    const { result } = renderHook(() =>
+      useConfirmOnUpdate<JsonData>({ confirmOn: ['delete'], onUpdate: inner })
+    )
+
+    let res!: Promise<unknown>
+    act(() => {
+      res = Promise.resolve(result.current.onUpdate(makeInput('delete')))
+    })
+
+    act(() => result.current.dialog.onConfirm())
+
+    await expect(res).resolves.toEqual({ value: 'committed' })
+    expect(inner).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips confirmation and calls inner directly for non-matching events', async () => {
+    const inner = jest.fn(() => undefined)
+    const { result } = renderHook(() =>
+      useConfirmOnUpdate<JsonData>({ confirmOn: ['delete'], onUpdate: inner })
+    )
+
+    let res!: Promise<unknown>
+    act(() => {
+      res = Promise.resolve(result.current.onUpdate(makeInput('edit')))
+    })
+
+    await expect(res).resolves.toBeUndefined()
+    expect(inner).toHaveBeenCalledTimes(1)
+    expect(result.current.dialog.isOpen).toBe(false)
+  })
+
+  it('supports a predicate confirmOn', async () => {
+    const { result } = renderHook(() =>
+      useConfirmOnUpdate({
+        confirmOn: (input) => input.event === 'delete' && input.key === 'secret',
+      })
+    )
+
+    // Non-matching key: no dialog, commits (undefined).
+    let skip!: Promise<unknown>
+    act(() => {
+      skip = Promise.resolve(result.current.onUpdate(makeInput('delete', { key: 'public' })))
+    })
+    await expect(skip).resolves.toBeUndefined()
+    expect(result.current.dialog.isOpen).toBe(false)
+
+    // Matching key: dialog opens.
+    act(() => {
+      void result.current.onUpdate(makeInput('delete', { key: 'secret' }))
+    })
+    expect(result.current.dialog.isOpen).toBe(true)
+  })
+
+  it('resolves a function message against the update input', () => {
+    const { result } = renderHook(() =>
+      useConfirmOnUpdate({
+        confirmOn: ['delete'],
+        title: 'Confirm',
+        message: (input) => `delete "${String(input.key)}"?`,
+      })
+    )
+
+    act(() => {
+      void result.current.onUpdate(makeInput('delete', { key: 'widget' }))
+    })
+
+    expect(result.current.dialog.title).toBe('Confirm')
+    expect(result.current.dialog.message).toBe('delete "widget"?')
+  })
+})

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -5,7 +5,21 @@
     "noEmit": true,
     "moduleResolution": "bundler",
     "typeRoots": ["../node_modules/@types"],
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    // The sub-packages import (types-only) from the bare 'json-edit-react'
+    // specifier, which doesn't resolve from the repo-root node_modules. Map it
+    // to core's source so ts-jest can type-check tests that pull in those hooks.
+    "baseUrl": "..",
+    "paths": {
+      "json-edit-react": ["src"],
+      "json-edit-react/*": ["src/*"]
+    }
   },
-  "include": ["**/*.ts", "**/*.tsx", "../src/**/*.ts", "../src/**/*.tsx"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "../src/**/*.ts",
+    "../src/**/*.tsx",
+    "../packages/utils/src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
Closes #307. The first real helper in `@json-edit-react/utils`: a pair of hooks that gate edits on a confirmation dialog by building on core's existing async `onUpdate` contract — **no core changes**.

## How it works

`JsonEditor` already `await`s `onUpdate` before committing and treats a returned `null` as a silent cancel. So an `onUpdate` that returns a promise which only resolves when the user answers a modal *just works* — the edit suspends until they do. These hooks package that deferred-promise recipe so consumers don't have to rediscover it.

## API (two layers)

- **`useJsonEditorConfirm`** — the primitive. A deferred-promise bridge: `confirm()` returns `Promise<boolean>`, and a `dialog` state object drives the consumer's own modal. BYO UI; you write the gating.
- **`useConfirmOnUpdate`** — declarative sugar over the primitive for the common "ask before these events" case: `confirmOn` (event-name array *or* predicate), static/function `title` + `message`, and an optional inner `onUpdate` that runs only after confirmation. Returns a ready-made `onUpdate` plus the same `dialog`.

The library ships **no modal** — `dialog` (`isOpen`, `title`, `message`, `onConfirm`, `onCancel`, + opaque extras) is the only contract. Zero runtime deps; types-only import from core (`JsonEditorEventName` is derived from `UpdateFunctionProps['event']` so it can't drift).

## What's in here

- `packages/utils/src/confirm-update/` — `types.ts`, `useJsonEditorConfirm.ts`, `useConfirmOnUpdate.ts`, barrel; re-exported from the package entry.
- `test/confirm.test.tsx` — 10 `renderHook` cases (resolve/cancel, opaque payload, re-entrancy, unmount safety, Layer 2 gating + array/predicate/message resolution). Plus a `paths` mapping in `test/tsconfig.json` so the type-only `json-edit-react` import resolves under ts-jest.
- `packages/utils/README.md` — present-tense usage docs.
- Changeset (`@json-edit-react/utils` minor, 0.0.0 → 0.1.0).

## Demo (Intro dataset)

Wired live on the **Intro** dataset so the behaviour is visible in dev — Layer 2 active (with a commented Layer 1 equivalent to flip between), via a Chakra `ConfirmDialog` (`demo/src/ConfirmDialog.tsx`). Adds the missing `@json-edit-react/utils` alias to the demo's `vite.config.ts` and `tsconfig.app.json`. The demo wiring is isolated and easy to comment out for production.

## Verification

- `pnpm test` — full suite green (incl. the new file); `pnpm --filter @json-edit-react/utils compile` + `build` clean; demo `tsc -p tsconfig.app.json` clean.
- Runtime smoke: demo dev server boots in `local` mode and resolves `@json-edit-react/utils` through the new alias.

## Follow-up (out of scope)

During this work we noticed the editor's optimistic pre-commit display (a value node shows the new value while an async `onUpdate` is pending; collection nodes invert it). Making the editor stay *open* until the commit resolves turns out to collide with the editing store's single-session / synchronous-close design, so it's filed separately as #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
