### PR TITLE
Fix type-switching away from custom nodes mid-edit

### DIFF
--- a/.changeset/component-confirm-fallback-fixes.md
+++ b/.changeset/component-confirm-fallback-fixes.md
@@ -1,0 +1,7 @@
+---
+'@json-edit-react/components': patch
+---
+
+Fix `BigInt` discarding edits on confirm: the keyboard confirm committed `BigInt(nodeData.value)` — the already-committed value — instead of the edited buffer. It now commits the typed value, falling back to the last valid value (with an `'Invalid BigInt'` `onError`) when the input isn't a valid integer string.
+
+Also fix `BigInt`, `DateObject` and `ColorPicker` displaying stale invalid text after an invalid-input fallback: committing the unchanged last-valid value doesn't alter the data, so the edit buffer never resynced. The fallback now resets the buffer explicitly.

--- a/.changeset/custom-node-type-switch-away.md
+++ b/.changeset/custom-node-type-switch-away.md
@@ -1,0 +1,11 @@
+---
+'json-edit-react': major
+---
+
+Fix type-switching away from a custom node mid-edit leaving an inconsistent editing UI (#335).
+
+Switching a custom node's type to a standard one now behaves like any other deferred primitive type change: the custom component yields to the target type's standard editor, pre-filled with a conversion of the node's actual value, and the single commit happens on confirm. Previously the custom component kept rendering over the editor while the buffer was silently replaced with the `DEFAULT_STRING` placeholder (`'New data!'`), which confirm then committed verbatim.
+
+Conversions are also safe for non-JSON sources: `null`/`undefined` → `string` yields an empty buffer (not the literal `"null"`/`"undefined"`), a `Symbol` converts to its description for `string` and to `0` for `number` (where it previously threw), and `NaN` → `number` yields `0`.
+
+**Breaking:** the `DEFAULT_STRING` localisation key is removed — the placeholder it supplied no longer exists. Remove it from your `translations` object if present.

--- a/README.md
+++ b/README.md
@@ -776,7 +776,7 @@ defaultValue = (_, newKey) => { // Ignoring normal first parameter in this case
 > [!NOTE]
 > The `newKeyOptions` and `defaultValue` functions needn't return anything -- if they don't, they'll just use:
 > - `newKeyOptions`: normal text input for new key
-> - `defaultValue`: an internal default (the `DEFAULT_STRING` value defined in [Localisation](#localisation))
+> - `defaultValue`: `null`
 </details>
 
 
@@ -1008,7 +1008,6 @@ Localise your implementation (or just customise the default messages) by passing
   ERROR_ADD: 'Adding node unsuccessful',
   ERROR_RENAME: 'Rename unsuccessful',
   ERROR_MOVE: 'Move unsuccessful',
-  DEFAULT_STRING: 'New data!',
   DEFAULT_NEW_KEY: 'key',
   SHOW_LESS: '(Show less)',
   EMPTY_STRING: '<empty string>' // Displayed when property key is ""

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -441,6 +441,10 @@ No action is strictly required — a `translations` object doesn't have to be ex
   }}
 ```
 
+### Removed localisation key: `DEFAULT_STRING`
+
+The `DEFAULT_STRING` key (`'New data!'`) is gone — if your `translations` object defines it, remove it (TypeScript rejects unknown keys). It was the placeholder substituted into the edit buffer when switching a custom node's type to `string`; type-switching now converts the node's actual value instead (e.g. a `null`/`undefined` source becomes an empty string), so the placeholder no longer exists.
+
 ---
 ## 10. Observers reshaped: `onEditEvent` lifecycle stream; flat `onError` / `onCollapse`; `onCopy` error
 

--- a/packages/components/src/BigInt/component.tsx
+++ b/packages/components/src/BigInt/component.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { toPathString, StringEdit, type CustomComponentProps } from 'json-edit-react'
 
 export interface BigIntProps {
@@ -16,10 +16,14 @@ export const BigIntComponent: React.FC<CustomComponentProps<BigIntProps>> = (pro
     componentProps = {},
     value,
     handleEdit,
+    onError,
     ...rest
   } = props
   const { path } = nodeData
   const { style = { color: '#006291', fontSize: '90%' } } = componentProps
+  const lastValidValue = useRef(value)
+
+  if (typeof value === 'bigint') lastValidValue.current = value
 
   const editDisplayValue = typeof value === 'bigint' ? String(value) : (value as string)
 
@@ -31,7 +35,13 @@ export const BigIntComponent: React.FC<CustomComponentProps<BigIntProps>> = (pro
       setValue={setValue as React.Dispatch<React.SetStateAction<string>>}
       {...rest}
       handleEdit={() => {
-        handleEdit(BigInt(nodeData.value as string))
+        try {
+          // BigInt() throws on anything non-integer ("1.5", "abc", "1e3")
+          handleEdit(BigInt(editDisplayValue))
+        } catch {
+          handleEdit(lastValidValue.current)
+          onError({ code: 'UPDATE_ERROR', message: 'Invalid BigInt' }, value)
+        }
       }}
     />
   ) : (

--- a/packages/components/src/BigInt/component.tsx
+++ b/packages/components/src/BigInt/component.tsx
@@ -4,6 +4,7 @@ import { toPathString, StringEdit, type CustomComponentProps } from 'json-edit-r
 export interface BigIntProps {
   style?: React.CSSProperties
   descriptionStyle?: React.CSSProperties
+  invalidBigIntError?: string
 }
 
 export const BigIntComponent: React.FC<CustomComponentProps<BigIntProps>> = (props) => {
@@ -20,7 +21,8 @@ export const BigIntComponent: React.FC<CustomComponentProps<BigIntProps>> = (pro
     ...rest
   } = props
   const { path } = nodeData
-  const { style = { color: '#006291', fontSize: '90%' } } = componentProps
+  const { style = { color: '#006291', fontSize: '90%' }, invalidBigIntError = 'Invalid BigInt' } =
+    componentProps
   const lastValidValue = useRef(value)
 
   if (typeof value === 'bigint') lastValidValue.current = value
@@ -43,7 +45,7 @@ export const BigIntComponent: React.FC<CustomComponentProps<BigIntProps>> = (pro
           // doesn't alter `data`, so nothing else clears the invalid text
           ;(setValue as (v: unknown) => void)(lastValidValue.current)
           handleEdit(lastValidValue.current)
-          onError({ code: 'UPDATE_ERROR', message: 'Invalid BigInt' }, value)
+          onError({ code: 'UPDATE_ERROR', message: invalidBigIntError }, value)
         }
       }}
     />

--- a/packages/components/src/BigInt/component.tsx
+++ b/packages/components/src/BigInt/component.tsx
@@ -39,6 +39,9 @@ export const BigIntComponent: React.FC<CustomComponentProps<BigIntProps>> = (pro
           // BigInt() throws on anything non-integer ("1.5", "abc", "1e3")
           handleEdit(BigInt(editDisplayValue))
         } catch {
+          // Reset the buffer too — committing the unchanged fallback
+          // doesn't alter `data`, so nothing else clears the invalid text
+          ;(setValue as (v: unknown) => void)(lastValidValue.current)
           handleEdit(lastValidValue.current)
           onError({ code: 'UPDATE_ERROR', message: 'Invalid BigInt' }, value)
         }

--- a/packages/components/src/ColorPicker/component.tsx
+++ b/packages/components/src/ColorPicker/component.tsx
@@ -116,6 +116,10 @@ export const ColorPickerComponent: React.FC<CustomComponentProps<ColorPickerProp
             }
             handleEdit={() => {
               if (keepAsColor && !colord(text).isValid()) {
+                // Reset the buffer too — committing the unchanged fallback
+                // doesn't alter `data`, so nothing else clears the invalid
+                // text
+                setValue(lastValidColor.current)
                 handleEdit(lastValidColor.current)
                 onError({ code: 'UPDATE_ERROR', message: invalidColorError }, text)
                 return

--- a/packages/components/src/DateObject/component.tsx
+++ b/packages/components/src/DateObject/component.tsx
@@ -3,6 +3,7 @@ import { StringDisplay, toPathString, StringEdit, type CustomComponentProps } fr
 
 export interface DateObjectProps {
   showTime?: boolean
+  invalidDateError?: string
 }
 
 export const DateObjectCustomComponent: React.FC<CustomComponentProps<DateObjectProps>> = (props) => {
@@ -19,7 +20,7 @@ export const DateObjectCustomComponent: React.FC<CustomComponentProps<DateObject
   } = props
   const lastValidDate = useRef(value)
 
-  const { showTime = true } = componentProps
+  const { showTime = true, invalidDateError = 'Invalid Date' } = componentProps
 
   if (value instanceof Date) lastValidDate.current = value
 
@@ -51,7 +52,7 @@ export const DateObjectCustomComponent: React.FC<CustomComponentProps<DateObject
           // doesn't alter `data`, so nothing else clears the invalid text
           ;(setValue as (v: unknown) => void)(lastValidDate.current)
           handleEdit(lastValidDate.current)
-          onError({ code: 'UPDATE_ERROR', message: 'Invalid Date' }, value)
+          onError({ code: 'UPDATE_ERROR', message: invalidDateError }, value)
         }
       }}
     />

--- a/packages/components/src/DateObject/component.tsx
+++ b/packages/components/src/DateObject/component.tsx
@@ -47,6 +47,9 @@ export const DateObjectCustomComponent: React.FC<CustomComponentProps<DateObject
           newDate.toISOString()
           handleEdit(newDate)
         } catch {
+          // Reset the buffer too — committing the unchanged fallback
+          // doesn't alter `data`, so nothing else clears the invalid text
+          ;(setValue as (v: unknown) => void)(lastValidDate.current)
           handleEdit(lastValidDate.current)
           onError({ code: 'UPDATE_ERROR', message: 'Invalid Date' }, value)
         }

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -249,14 +249,7 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
       return
     }
 
-    const newValue = convertValue(
-      value,
-      type,
-      translate('DEFAULT_NEW_KEY', nodeData),
-      // If coming *FROM* a custom type, change value to something that no
-      // longer matches the custom node condition.
-      customNodeData?.CustomComponent ? translate('DEFAULT_STRING', nodeData) : undefined
-    )
+    const newValue = convertValue(value, type, translate('DEFAULT_NEW_KEY', nodeData))
 
     if (type === 'object' || type === 'array' || type === 'null') {
       // Commit immediately and close the editor: a collection is structural (it
@@ -334,8 +327,18 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
   const showTypeSelector = isEditing && allowedDataTypes.length > 1
   const showEditButtons = (dataType !== 'invalid' || CustomComponent) && !error && showEditTools
   const shouldShowKey = showLabel && showKey
+  // A local (deferred) type-switch is in progress when the editing `dataType`
+  // has moved away from what the committed data reports — `revertToData`
+  // resyncs them whenever a session ends, so mid-session divergence can only
+  // come from the type selector. The custom-component match (`customNodeData`)
+  // is keyed off committed data, so it still claims this node mid-switch; the
+  // switched-to type's standard editor must win until the edit commits or
+  // cancels.
+  const typeSwitchedAway = isEditing && dataType !== getDataType(data, customNodeData)
   const showCustomNode =
-    CustomComponent && ((isEditing && showOnEdit) || (!isEditing && showOnView))
+    CustomComponent &&
+    !typeSwitchedAway &&
+    ((isEditing && showOnEdit) || (!isEditing && showOnView))
 
   // Open this node's edit session, reverting the buffer if it's cancelled.
   // `setIsEditing` is the `canEdit`-gated callable handed to value inputs and
@@ -555,19 +558,21 @@ const getInputComponent = (data: JsonData, dataType: DataType | string, inputPro
 // input ("-", "", "1.2.3"). Shared by `handleEdit`'s commit path and the
 // to-number case of `convertValue`.
 const toNumberOrZero = (value: unknown): number => {
+  // Number(symbol) throws rather than returning NaN
+  if (typeof value === 'symbol') return 0
   const n = Number(value)
   return isNaN(n) ? 0 : n
 }
 
-const convertValue = (
-  value: unknown,
-  type: DataType,
-  defaultNewKey: string,
-  defaultString?: string
-) => {
+const convertValue = (value: unknown, type: DataType, defaultNewKey: string) => {
   switch (type) {
     case 'string':
-      return defaultString ?? String(value)
+      // Non-JSON sources need care: null/undefined have no string
+      // representation worth editing (empty buffer beats the literal "null"),
+      // and a symbol's editable text is its description, not String(symbol)
+      if (value == null) return ''
+      if (typeof value === 'symbol') return value.description ?? ''
+      return String(value)
     case 'number':
       return toNumberOrZero(value)
     case 'boolean':

--- a/src/localisation.ts
+++ b/src/localisation.ts
@@ -13,7 +13,6 @@ const localisedStrings = {
   ERROR_ADD: 'Adding node unsuccessful',
   ERROR_RENAME: 'Rename unsuccessful',
   ERROR_MOVE: 'Move unsuccessful',
-  DEFAULT_STRING: 'New data!',
   DEFAULT_NEW_KEY: 'key',
   SHOW_LESS: '(Show less)',
   EMPTY_STRING: '<empty string>',

--- a/test/JsonEditor.test.tsx
+++ b/test/JsonEditor.test.tsx
@@ -737,7 +737,7 @@ describe('JsonEditor — structural mutations', () => {
   test('switching the value type renders the matching input, not the committed type', async () => {
     const user = userEvent.setup()
     const { container } = render(<JsonEditor data={{ x: 'hello' }} setData={noop} />)
-    const typeSelect = () => container.querySelector('.jer-select-types select') as HTMLSelectElement
+    const typeSelect = () => container.querySelector('select[name="x-type-select"]') as HTMLSelectElement
 
     await user.dblClick(screen.getByText('"hello"'))
     // String value → the string textarea editor.
@@ -762,18 +762,36 @@ describe('JsonEditor — structural mutations', () => {
     expect(container.querySelector('input.jer-input-boolean')).toBeNull()
   })
 
+  test('changing type null → string pre-fills an empty editor, not the literal "null"', async () => {
+    const user = userEvent.setup()
+    const setData = jest.fn()
+    const { container } = render(<JsonEditor data={{ x: null }} setData={setData} />)
+
+    await user.dblClick(screen.getByText('null'))
+    await user.selectOptions(screen.getByRole('combobox'), 'string')
+
+    // A null source has no string representation worth editing — the buffer
+    // must be empty, not String(null).
+    const input = container.querySelector('textarea.jer-input-text') as HTMLTextAreaElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe('')
+
+    await user.type(input, 'typed{Enter}')
+    expect(setData).toHaveBeenCalledWith({ x: 'typed' })
+  })
+
   test('changing the type to null commits immediately and closes the editor', async () => {
     const user = userEvent.setup()
     const setData = jest.fn()
     const { container } = render(<JsonEditor data={{ x: 'hello' }} setData={setData} />)
 
     await user.dblClick(screen.getByText('"hello"'))
-    await user.selectOptions(container.querySelector('.jer-select-types select') as HTMLSelectElement, 'null')
+    await user.selectOptions(container.querySelector('select[name="x-type-select"]') as HTMLSelectElement, 'null')
 
     // `null` has no value to edit, so selecting it commits straight away — no
     // OK/Enter needed — and the editor closes (the type selector disappears).
     expect(setData).toHaveBeenCalledWith({ x: null })
-    expect(container.querySelector('.jer-select-types')).toBeNull()
+    expect(container.querySelector('select[name="x-type-select"]')).toBeNull()
   })
 
   test('changing the type to object commits a collection immediately and re-renders as one', async () => {
@@ -797,7 +815,7 @@ describe('JsonEditor — structural mutations', () => {
 
     await user.dblClick(screen.getByText('"hello"'))
     await user.selectOptions(
-      container.querySelector('.jer-select-types select') as HTMLSelectElement,
+      container.querySelector('select[name="x-type-select"]') as HTMLSelectElement,
       'object'
     )
 
@@ -805,7 +823,7 @@ describe('JsonEditor — structural mutations', () => {
     // with the converted default ({ [DEFAULT_NEW_KEY]: value }) and closes the
     // editor — so `handleEdit` never sees an 'object' dataType.
     expect(setData).toHaveBeenCalledWith({ x: { key: 'hello' } })
-    expect(container.querySelector('.jer-select-types')).toBeNull()
+    expect(container.querySelector('select[name="x-type-select"]')).toBeNull()
 
     // `x` now renders as a collection: the new child key appears (it had no key
     // as a string value node), proving the value re-rendered through
@@ -832,14 +850,14 @@ describe('JsonEditor — structural mutations', () => {
 
     await user.dblClick(screen.getByText('"hello"'))
     await user.selectOptions(
-      container.querySelector('.jer-select-types select') as HTMLSelectElement,
+      container.querySelector('select[name="x-type-select"]') as HTMLSelectElement,
       'array'
     )
 
     // To-array wraps the value ([value]) and commits + closes, same as
     // object/null — `handleEdit` never sees an 'array' dataType.
     expect(setData).toHaveBeenCalledWith({ x: ['hello'] })
-    expect(container.querySelector('.jer-select-types')).toBeNull()
+    expect(container.querySelector('select[name="x-type-select"]')).toBeNull()
 
     // `x` now renders as an array collection: a square open-bracket appears
     // (the root object only contributes a `{`), proving it re-rendered as a
@@ -1468,7 +1486,7 @@ describe('JsonEditor — restrictions and callbacks', () => {
         allowTypeSelection={['string', { enum: 'Color', values: ['red', 'green', 'blue'] }]}
       />
     )
-    const typeSelect = () => container.querySelector('.jer-select-types select') as HTMLSelectElement
+    const typeSelect = () => container.querySelector('select[name="x-type-select"]') as HTMLSelectElement
 
     // Enter edit mode on the value — the type <select> appears
     await user.dblClick(screen.getByText('"hello"'))
@@ -1486,7 +1504,7 @@ describe('JsonEditor — restrictions and callbacks', () => {
     expect(onUpdate).toHaveBeenCalled()
 
     // The rejection reverts the value and closes the edit session.
-    await waitFor(() => expect(container.querySelector('.jer-select-types')).toBeNull())
+    await waitFor(() => expect(container.querySelector('select[name="x-type-select"]')).toBeNull())
     expect(screen.getByText('"hello"')).toBeInTheDocument()
 
     // Re-open editing: the type selector must reflect the reverted value

--- a/test/customNode.test.tsx
+++ b/test/customNode.test.tsx
@@ -271,6 +271,147 @@ describe('CustomNode — type selector & defaultValue', () => {
   })
 })
 
+describe('CustomNode — switching type away mid-edit', () => {
+  // Mirrors the shipped non-JSON components (`undefined`, `NaN`, `Symbol`):
+  // value-keyed condition, shown while editing, listed in the type selector.
+  // A type-switch away is deferred (local buffer only) like any primitive
+  // type change, so the custom component must yield to the target type's
+  // standard editor immediately — even though the committed data still
+  // matches the condition until the edit is confirmed.
+  const nonJsonDef = (
+    condition: CustomNodeDefinition['condition'],
+    name: string,
+    defaultValue: unknown
+  ): CustomNodeDefinition => ({
+    condition,
+    component: () => <span data-testid="custom">CUSTOM</span>,
+    showOnEdit: true,
+    name,
+    showInTypeSelector: true,
+    defaultValue,
+  })
+
+  const undefinedDef = nonJsonDef(({ value }) => value === undefined, 'undefined', undefined)
+  const nanDef = nonJsonDef(({ value }) => Number.isNaN(value), 'NaN', NaN)
+  const symbolDef = nonJsonDef(({ value }) => typeof value === 'symbol', 'Symbol', Symbol('new'))
+
+  const startEdit = async (user: ReturnType<typeof userEvent.setup>) => {
+    const row = screen.getByTestId('custom').closest('.jer-component') as HTMLElement
+    await user.click(within(row).getByTitle('Edit'))
+  }
+
+  test('undefined → string: the standard string editor appears, empty, and commits typed text', async () => {
+    const user = userEvent.setup()
+    const setData = jest.fn()
+    const { container } = render(
+      <JsonEditor
+        data={{ x: undefined }}
+        setData={setData}
+        customNodeDefinitions={[undefinedDef]}
+        showIconTooltips
+      />
+    )
+    await startEdit(user)
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('undefined')
+
+    await user.selectOptions(screen.getByRole('combobox'), 'string')
+
+    // The custom component yields to the string editor, whose buffer is empty
+    // (not the DEFAULT_STRING localisation text).
+    expect(screen.queryByTestId('custom')).toBeNull()
+    const input = container.querySelector('textarea.jer-input-text') as HTMLTextAreaElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe('')
+
+    await user.type(input, 'hello')
+    await user.click(container.querySelectorAll('.jer-confirm-buttons > div')[0])
+    expect(setData).toHaveBeenCalledWith({ x: 'hello' })
+  })
+
+  test('NaN → number: the numeric editor appears with 0 and commits', async () => {
+    const user = userEvent.setup()
+    const setData = jest.fn()
+    const { container } = render(
+      <JsonEditor
+        data={{ x: NaN }}
+        setData={setData}
+        customNodeDefinitions={[nanDef]}
+        showIconTooltips
+      />
+    )
+    await startEdit(user)
+    await user.selectOptions(screen.getByRole('combobox'), 'number')
+
+    expect(screen.queryByTestId('custom')).toBeNull()
+    const input = container.querySelector('input.jer-input-number') as HTMLInputElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe('0')
+
+    await user.click(container.querySelectorAll('.jer-confirm-buttons > div')[0])
+    expect(setData).toHaveBeenCalledWith({ x: 0 })
+  })
+
+  test('Symbol → string: the string editor pre-fills the symbol description', async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <JsonEditor
+        data={{ x: Symbol('my description') }}
+        setData={noop}
+        customNodeDefinitions={[symbolDef]}
+        showIconTooltips
+      />
+    )
+    await startEdit(user)
+    await user.selectOptions(screen.getByRole('combobox'), 'string')
+
+    expect(screen.queryByTestId('custom')).toBeNull()
+    const input = container.querySelector('textarea.jer-input-text') as HTMLTextAreaElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe('my description')
+  })
+
+  test('Symbol → number: coerces to 0 instead of throwing (Number(symbol) throws)', async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <JsonEditor
+        data={{ x: Symbol('sym') }}
+        setData={noop}
+        customNodeDefinitions={[symbolDef]}
+        showIconTooltips
+      />
+    )
+    await startEdit(user)
+    await user.selectOptions(screen.getByRole('combobox'), 'number')
+
+    expect(screen.queryByTestId('custom')).toBeNull()
+    const input = container.querySelector('input.jer-input-number') as HTMLInputElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe('0')
+  })
+
+  test('cancelling after a switch-away restores the custom node, nothing committed', async () => {
+    const user = userEvent.setup()
+    const setData = jest.fn()
+    const { container } = render(
+      <JsonEditor
+        data={{ x: undefined }}
+        setData={setData}
+        customNodeDefinitions={[undefinedDef]}
+        showIconTooltips
+      />
+    )
+    await startEdit(user)
+    await user.selectOptions(screen.getByRole('combobox'), 'string')
+
+    const input = container.querySelector('textarea.jer-input-text') as HTMLTextAreaElement
+    await user.type(input, 'discard-me{Escape}')
+
+    expect(setData).not.toHaveBeenCalled()
+    expect(screen.getByTestId('custom')).toBeInTheDocument()
+    expect(container.querySelector('textarea.jer-input-text')).toBeNull()
+  })
+})
+
 describe('CustomNode — passOriginalNode', () => {
   test('passOriginalNode true → the original node is provided for re-rendering', () => {
     const defs: CustomNodeDefinition[] = [


### PR DESCRIPTION
Closes #335

## What was wrong

Two interlocking bugs in core, plus component-level issues found in the audit:

1. **Render keying** — the decision to render a custom component (`showCustomNode`) is keyed off `customNodeData`, which matches conditions against *committed* data. V2's primitive type-switch is deferred (local buffer + `dataType` only, single commit on ✓), so after switching e.g. `undefined → string` the committed data still matched the custom condition and the custom component kept rendering — the target type's editor never appeared.
2. **`DEFAULT_STRING` substitution** — switching *from* a custom type replaced the buffer with `'New data!'`, a V1-era trick to make the value stop matching the custom condition under the old immediate-commit model. Under the deferred model it was invisible (because of bug 1) and committed verbatim on ✓.
3. **Non-JSON coercion hazards** — `Number(symbol)` throws, so Symbol → number silently aborted the handler; `null → string` pre-filled the literal `"null"` (the #335 fold-in, originally #229).

## The fix

- While editing, if local `dataType` differs from what committed data reports, a type-switch is in progress and the standard editor for the switched-to type wins. No new state: `revertToData` resyncs `dataType` whenever a session ends, so mid-session divergence can only come from the type selector.
- The `DEFAULT_STRING` substitution is gone — `convertValue` converts the node's actual value, non-JSON-safely: `null`/`undefined → ''`, `Symbol →` its description for string / `0` for number (no longer throws), `NaN → 0`. For the non-JSON types the converted values naturally stop matching their conditions; for condition-matched types like dates, committing an unchanged value re-matching the condition is condition-based rendering working as designed.
- **Breaking:** the `DEFAULT_STRING` localisation key is removed (no remaining consumers). Migration guide + README updated; the README's `defaultValue` note was already stale (the new-value fallback has been `null` since v1).

## Component audit (all 12 shipped components)

| Component | Confirm path | Outcome |
|---|---|---|
| Undefined, NaN | commit buffer via core `handleEdit()` | ✓ fine post-core-fix |
| Symbol | `Symbol(editDisplayValue)` from live buffer | ✓ correct |
| **BigInt** | `BigInt(nodeData.value)` — committed value, **edits discarded**; throws on invalid input | **fixed** |
| DateObject, ColorPicker | last-valid fallback + `onError` | ✓ pattern correct; stale-buffer quirk fixed (below) |
| DatePicker, EnhancedLink | live buffer / local state | ✓ |
| BooleanToggle | instant toggle (no session) | ✓ |
| Hyperlink, Image, Markdown | view-only | n/a |
| CodeEditor, ReactSelect | not custom nodes (`TextEditor` / `CustomSelect` replacements) | n/a |

- BigInt now commits the edited buffer, with invalid integer strings falling back to the last valid value + `'Invalid BigInt'` via `onError` (the DateObject pattern).
- BigInt/DateObject/ColorPicker shared a fallback quirk: committing the *unchanged* last-valid value doesn't alter `data`, so the buffer never resynced and the closed editor kept displaying the invalid text. The fallback now resets the buffer explicitly.

## Tests

Six new regression tests, all written first and failing with the predicted symptoms:

- core: `null → string` pre-fills `''` and commits typed text
- custom nodes: undefined → string shows the standard editor with an empty buffer (not `'New data!'`) and commits typed text; NaN → number gives `0`; Symbol → string pre-fills the description; Symbol → number coerces to `0` instead of throwing; Escape after a switch restores the custom node

Also repairs five pre-existing test failures: they queried `.jer-select-types`, which the NativeSelect refactor (#337) removed from the markup — they now target the select's `name` attribute.

## Verified in the demo

Drove the CCL data set's Non-JSON types group headless (Playwright, `pnpm dev`): all repro steps from #335 now behave as the issue's Expected section describes, including commit/cancel round-trips and the BigInt invalid-input probe.

## Out of scope, flagged for follow-up

- #337 dropped the `.jer-select-types` / `.jer-select-enums` / `.jer-select-keys` wrapper classes — consumer CSS hooks gone, and `CustomSelect` implementers can't tell which dropdown they're rendering. Could be restored via a wrapper-class prop on `NativeSelect`.
- The ✓ OK button bypasses custom components' confirm transforms (pre-existing): it commits the raw string buffer, while Enter routes through the component's transform — so ✓ on a BigInt/Symbol/DateObject edit commits a plain string. Affects every buffer-editing component; likely needs a per-definition commit transform (new API).
- `@json-edit-react/components` has no test infrastructure — its fixes here are browser-verified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)