### PR TITLE
Fix editor crash when the Markdown component receives a non-string value

### DIFF
--- a/.changeset/markdown-non-string-crash.md
+++ b/.changeset/markdown-non-string-crash.md
@@ -1,0 +1,5 @@
+---
+'@json-edit-react/components': patch
+---
+
+The Markdown component no longer crashes the editor when its node's value isn't a string. react-markdown throws on non-string children, and a value-type-agnostic condition (e.g. matching by key) could feed it one — switching a matched node's type to number and committing took down the whole tree. Non-string values now render via their string representation.

--- a/demo/src/demoData/dataDefinitions.tsx
+++ b/demo/src/demoData/dataDefinitions.tsx
@@ -1103,11 +1103,13 @@ export const demoDataDefinitions: Record<string, DemoData> = {
       ColorPickerNodeDefinition,
       {
         ...MarkdownNodeDefinition,
-        condition: ({ key }) => key === 'Markdown',
+        // Value-type check so a node switched to another type (e.g. number)
+        // renders natively rather than as markdown text
+        condition: ({ key, value }) => key === 'Markdown' && typeof value === 'string',
       },
       {
         ...MarkdownNodeDefinition,
-        condition: ({ key }) => key === 'Intro',
+        condition: ({ key, value }) => key === 'Intro' && typeof value === 'string',
         showKey: false,
         componentProps: {
           components: {

--- a/packages/components/src/Markdown/component.tsx
+++ b/packages/components/src/Markdown/component.tsx
@@ -16,8 +16,14 @@ export interface MarkdownCustomProps extends Options {
 }
 
 export const MarkdownComponent: React.FC<CustomComponentProps<MarkdownCustomProps>> = (props) => {
-  const { setIsEditing, getStyles, nodeData, componentProps } = props
+  const { setIsEditing, getStyles, nodeData, componentProps, value } = props
   const styles = getStyles('string', nodeData)
+
+  // react-markdown THROWS on non-string children, which would crash the whole
+  // editor tree. A consumer condition (e.g. key-based) can leave this
+  // component matched against a non-string value — say, after a type-switch
+  // to number — so coerce anything else to its string representation.
+  const markdownText = String(value ?? '')
 
   return (
     <div
@@ -29,7 +35,7 @@ export const MarkdownComponent: React.FC<CustomComponentProps<MarkdownCustomProp
       className="jer-markdown-block"
     >
       <Suspense fallback={<Loading text={componentProps?.loadingText ?? 'Loading Markdown'} />}>
-        <Markdown {...props.componentProps}>{nodeData.value as string}</Markdown>
+        <Markdown {...props.componentProps}>{markdownText}</Markdown>
       </Suspense>
     </div>
   )


### PR DESCRIPTION
Fixes a crash reported during #339/#340 work, but **pre-existing on `v2.0-dev`** (the Markdown component is untouched since #324) and independent of that PR stack — hence a standalone PR straight into `v2.0-dev`.

## Repro (before)

Custom Component Library demo → edit a Markdown node → switch type string → number → enter a number → submit → the whole editor unmounts with:

```
Unexpected value `42` for `children` prop, expected `string`
```

## Cause

react-markdown **throws** on non-string children. The demo's Markdown conditions match by key only (`({ key }) => key === 'Markdown'`), so after committing a number at that key the condition still matches and `MarkdownComponent` hands react-markdown a number. No error boundary above it → the tree unmounts. The boolean switch crashes identically; `null` happens to be tolerated by react-markdown, which is why only some switches blew up.

## Fix

- **`@json-edit-react/components`** (the published fix): `MarkdownComponent` coerces its value via `String(value ?? '')` before passing it to react-markdown — any consumer with a value-type-agnostic condition is now safe.
- **Demo**: both Markdown conditions gain `typeof value === 'string'`, so a switched-to-number node renders as a native number rather than as markdown text.

## Verification

No jest coverage is practical here (the components package has no test infra and react-markdown is ESM-only), so this was pinned by driving the demo with Playwright, before and after:

- Before (on plain `v2.0-dev`): the repro above captured the pageerror and the unmounted tree.
- After: number commit → no errors, editor alive, `Markdown: 42` renders as a standard number node; switching back to string with `## Heading restored` renders markdown again; the boolean variant of the same crash class also commits cleanly.

Changeset: `@json-edit-react/components` **patch**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)