### PR TITLE
Filtered collection counts + filter rewrite (#113)

### DIFF
--- a/.changeset/filtered-collection-counts-and-filter-rewrite.md
+++ b/.changeset/filtered-collection-counts-and-filter-rewrite.md
@@ -1,0 +1,16 @@
+---
+'json-edit-react': minor
+---
+
+Collection counts now reflect the active search filter, displayed as "n of m" (e.g. `"3 of 20 items"`) whenever search is narrowing the visible children. `showCollectionCount` gains a new `'when-closed-or-filtered'` literal that surfaces the count on a collection whenever it's collapsed *or* a search filter is active — this is the new default, so the n-of-m form is visible without users having to close the node. Pass `'when-closed'` for the previous behaviour, or override `customText.ITEMS_FILTERED` (e.g. returning `${size} items`) to suppress the n-of-m form entirely.
+
+Internally, the per-node `filterNode` cascade is replaced with a single post-order walk at the editor level (`computeFilterState`) that produces both whole-tree visibility and per-collection visible-child counts in one pass. The new walk is also surfaced to nodes via a new `FilterStateProvider` context slice — `searchText`/`searchFilter` are no longer threaded as per-node props, which strengthens the §16 node memoization.
+
+Two related bug fixes fall out of the rewrite:
+
+- An intermediate collection whose key matched the search filter but whose body was empty (or whose descendants weren't path-aware-matched) used to drop out and drag its ancestors with it. The new walk tests every node, including intermediate collections, so the matching node and its ancestors stay visible. This was observable with a custom `searchFilter` that only inspected `key`, and with the built-in `'key'` filter on empty `{}` / `[]` bodies.
+- `index` on the synthesized `childNodeData` a custom `searchFilter` receives is now the position within visible children (matching `buildNodeData` semantics); previously it was inherited from the parent and frequently stale. `size` is now the child's actual collection size; previously it was the path depth.
+
+The `ITEMS_FILTERED` localisation key (default `'{{visible}} of {{total}} items'`) drives the new display. A `customText.ITEMS_FILTERED` override receives the standard `NodeData` plus a new `visibleSize` field carrying the visible-child count alongside the existing `size` (the total).
+
+The internal `filterNode` and `filterCollection` helpers are removed — they were never re-exported from the package entry point and aren't user-facing. `matchNode` and `matchNodeKey` are unchanged.

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ This is a reference list of *all* possible props, divided into related sections.
 | `showArrayIndexes`      | `boolean`                                 | `true`               | Whether or not to display the index (as a property key) for array elements.                                                                                                                                                                                                                                                                                                                               |
 | `arrayIndexStart`       | `0 \| 1`                                  | `0`                  | The number the *first* array element's index label starts from. `0` (default) gives `0, 1, 2…`; `1` gives `1, 2, 3…`.                                                                                                                                                                                                                                                                                     |
 | `showStringQuotes`      | `boolean`                                 | `true`               | Whether or not to display string values in "quotes".                                                                                                                                                                                                                                                                                                                                                      |
-| `showCollectionCount`   | `boolean\|"when-closed"`                  | `"when-closed"`      | Whether or not to display the number of items in each collection (object or array). `"when-closed"` shows the count only on collapsed collections.                                                                                                                                                                                                                                                        |
+| `showCollectionCount`   | `boolean\|"when-closed"\|"when-closed-or-filtered"` | `"when-closed-or-filtered"` | Whether or not to display the number of items in each collection (object or array). `"when-closed"` shows the count only on collapsed collections; `"when-closed-or-filtered"` (the default) additionally shows it whenever a search filter is active, so the `n of m` count is visible without having to close the node. When the count is shown and a search filter has narrowed the visible children, it renders as `"n of m items"` (using the [`ITEMS_FILTERED`](#localisation) string). |
 | `stringTruncateLength`  | `number`                                  | `250`                | String values longer than this many characters will be displayed truncated (with `...`). The full string will always be visible when editing.                                                                                                                                                                                                                                                             |
 | `sortKeys`              | `boolean\|CompareFunction`                | `false`              | If `true`, object keys will be ordered (using default JS `.sort()`). A [compare function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) can also be provided to define sorting behaviour, except the input type should be a tuple of the key and the value of a node i.e. `(a: [string \| number, ValueData], b: [string \| number, ValueData]) => number` |
 | `minWidth`              | `number\|string` (CSS value)              | `250`                | Minimum width for the editor container.                                                                                                                                                                                                                                                                                                                                                                   |
@@ -999,6 +999,7 @@ Localise your implementation (or just customise the default messages) by passing
 {
   ITEM_SINGLE: '{{count}} item',
   ITEMS_MULTIPLE: '{{count}} items',
+  ITEMS_FILTERED: '{{visible}} of {{total}} items', // Shown when a search filter is active and the visible count differs from the total. Both `{{visible}}` and `{{total}}` are substituted.
   KEY_NEW: 'Enter new key',
   KEY_SELECT: 'Select key',
   NO_KEY_OPTIONS: 'No key options',
@@ -1212,6 +1213,8 @@ customText = {
   ITEMS_MULTIPLE: itemCountReplacement,
 }
 ```
+
+When a search filter is active, the count switches to `ITEMS_FILTERED` (e.g. `"3 of 20 items"`). A `customText` callback for that key receives the same `NodeData` input plus an additional `visibleSize` field carrying the count of visible direct children — so both numbers are available to the override (`size` is the total, `visibleSize` is the visible count).
 
 ## Custom Buttons
 

--- a/README.md
+++ b/README.md
@@ -562,6 +562,10 @@ These each take a `boolean` value, or a `FilterFunction` callback, with the foll
     value,      // value of the property
     size ,      // if a collection (object, array), the number of items
                 //   (null for non-collections)
+    visibleSize, // if a collection AND a search filter is active, the
+                //   number of direct children currently visible
+                //   (undefined otherwise — i.e. on leaves, or when no
+                //   filter is active)
     parentData, // parent object containing the current node
     fullData    // the full (overall) data object
     collapsed   // whether or not the current node is in a
@@ -999,7 +1003,7 @@ Localise your implementation (or just customise the default messages) by passing
 {
   ITEM_SINGLE: '{{count}} item',
   ITEMS_MULTIPLE: '{{count}} items',
-  ITEMS_FILTERED: '{{visible}} of {{total}} items', // Shown when a search filter is active and the visible count differs from the total. Both `{{visible}}` and `{{total}}` are substituted.
+  ITEMS_FILTERED: '{{visible}} of {{total}} items',
   KEY_NEW: 'Enter new key',
   KEY_SELECT: 'Select key',
   NO_KEY_OPTIONS: 'No key options',
@@ -1214,7 +1218,7 @@ customText = {
 }
 ```
 
-When a search filter is active, the count switches to `ITEMS_FILTERED` (e.g. `"3 of 20 items"`). A `customText` callback for that key receives the same `NodeData` input plus an additional `visibleSize` field carrying the count of visible direct children — so both numbers are available to the override (`size` is the total, `visibleSize` is the visible count).
+When a search filter is active, the count switches to `ITEMS_FILTERED` (e.g. `"3 of 20 items"`). The override receives the standard `NodeData`, with `size` as the total and `visibleSize` (set on every collection node while a filter is active — see [Filter functions](#filter-functions)) as the visible count.
 
 ## Custom Buttons
 

--- a/README.md
+++ b/README.md
@@ -562,10 +562,15 @@ These each take a `boolean` value, or a `FilterFunction` callback, with the foll
     value,      // value of the property
     size ,      // if a collection (object, array), the number of items
                 //   (null for non-collections)
-    visibleSize, // if a collection AND a search filter is active, the
-                //   number of direct children currently visible
-                //   (undefined otherwise — i.e. on leaves, or when no
-                //   filter is active)
+    visibleSize, // direct-child count under the current search filter.
+                //   `number` on collections under an active filter;
+                //   `null` on render-path nodes when no filter is active
+                //   or this isn't a tracked collection (e.g. a leaf).
+                //   `undefined` only inside the `searchFilter` callback
+                //   itself (the walk hasn't computed counts yet) or when
+                //   NodeData reaches you via an imperative bridge
+                //   (onCollapse / onEditEvent / the editorRef handle).
+                //   Use `!= null` to gate on "has a real count".
     parentData, // parent object containing the current node
     fullData    // the full (overall) data object
     collapsed   // whether or not the current node is in a

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -65,7 +65,7 @@ interface AppState {
   indent: number
   collapseLevel: number | FilterFunction
   collapseTime: number
-  showCount: 'Yes' | 'No' | 'When closed'
+  showCount: 'Yes' | 'No' | 'When closed' | 'When closed or filtered'
   theme: Theme
   allowEdit: boolean
   allowDelete: boolean
@@ -115,7 +115,7 @@ function App() {
     indent: 2,
     collapseLevel: dataDefinition.collapse ?? 2,
     collapseTime: 300,
-    showCount: 'When closed',
+    showCount: 'When closed or filtered',
     theme: defaultTheme,
     allowEdit: true,
     allowDelete: true,
@@ -553,7 +553,13 @@ function App() {
                   collapse={collapseLevel}
                   collapseAnimationTime={collapseTime}
                   showCollectionCount={
-                    showCount === 'Yes' ? true : showCount === 'When closed' ? 'when-closed' : false
+                    showCount === 'Yes'
+                      ? true
+                      : showCount === 'When closed'
+                        ? 'when-closed'
+                        : showCount === 'When closed or filtered'
+                          ? 'when-closed-or-filtered'
+                          : false
                   }
                   allowClipboard={allowCopy}
                   onCopy={onCopy}
@@ -857,7 +863,13 @@ function App() {
                     <Select
                       id="showCountSelect"
                       onChange={(e) =>
-                        updateState({ showCount: e.target.value as 'Yes' | 'No' | 'When closed' })
+                        updateState({
+                          showCount: e.target.value as
+                            | 'Yes'
+                            | 'No'
+                            | 'When closed'
+                            | 'When closed or filtered',
+                        })
                       }
                       value={showCount}
                     >
@@ -869,6 +881,9 @@ function App() {
                       </option>
                       <option value="When closed" key={2}>
                         When closed
+                      </option>
+                      <option value="When closed or filtered" key={3}>
+                        When closed or filtered
                       </option>
                     </Select>
                   </div>

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -491,7 +491,7 @@ function App() {
                 borderColor="gainsboro"
                 borderRadius={50}
                 size="sm"
-                w={20}
+                w={'8rem'}
                 value={searchText}
                 onChange={(e) => updateState({ searchText: e.target.value })}
                 position="absolute"
@@ -872,6 +872,7 @@ function App() {
                         })
                       }
                       value={showCount}
+                      fontSize="sm"
                     >
                       <option value="Yes" key={0}>
                         Yes

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -557,7 +557,19 @@ A handful of props were renamed. These are **pure renames** (no behaviour change
 
 > The same `stringTruncate` → `stringTruncateLength` rename applies to the `componentProps` of the `Hyperlink` / `EnhancedLink` components in `@json-edit-react/components`.
 
-One display **default** also changed (not a rename): `showCollectionCount` now defaults to `"when-closed"` (previously `true`), so item counts show only on collapsed collections. To keep the v1 always-visible behaviour, set `showCollectionCount={true}`.
+One display **default** also changed (not a rename): `showCollectionCount` now defaults to `"when-closed-or-filtered"` (previously `true`). Counts appear when a collection is collapsed *or* when a search filter is narrowing its children — in the latter case rendered as `"n of m items"`. To keep the v1 always-visible behaviour, set `showCollectionCount={true}`; for collapse-only, set `"when-closed"`.
+
+The filtered-count form is driven by a new localisation key, `ITEMS_FILTERED`. If you ship a complete `translations` object, add it (otherwise the English default `"{{visible}} of {{total}} items"` will appear alongside your translated UI whenever a search filter is active):
+
+```diff
+  translations={{
+    // ...existing keys
+    ITEMS_MULTIPLE: '…',
++   ITEMS_FILTERED: '… {{visible}} … {{total}} …',
+  }}
+```
+
+Both `{{visible}}` and `{{total}}` placeholders are substituted at render time.
 
 ---
 

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -214,8 +214,9 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
   const isVisible = useNodeVisible(path) || nodeData.level === 0
   if (!isVisible && !childrenEditing) return null
 
-  // `visibleSize` is set by useCommon when a filter is active; undefined
-  // otherwise. Drives the "n of m" filtered-count display below.
+  // `visibleSize` is a number on tracked collections while a filter is
+  // active; `null` on leaves under a filter; `undefined` otherwise. Use
+  // `!= null` to check "has a real count". Drives the n-of-m display.
   const { visibleSize } = nodeData
 
   const collectionType = Array.isArray(data) ? 'array' : 'object'
@@ -344,12 +345,14 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
   const showLabel = showArrayIndexes || !isArray
   // `'when-closed-or-filtered'` surfaces the count whenever the filter is
   // currently subsetting this collection's children — useCommon sets
-  // `visibleSize` only while a filter is active.
+  // `visibleSize` to a number on tracked collections while a filter is
+  // active (and `null` on leaves), so `!= null` catches "filter active
+  // AND we have a real count for this node".
   const showCount =
     showCollectionCount === 'when-closed'
       ? collapsed
       : showCollectionCount === 'when-closed-or-filtered'
-        ? collapsed || visibleSize !== undefined
+        ? collapsed || visibleSize != null
         : showCollectionCount
   const showEditButtons = !isEditing && showEditTools
   const shouldShowKey = showLabel && showKey && name !== undefined
@@ -601,7 +604,7 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
                 transitionBehavior: 'allow-discrete',
               }}
             >
-              {visibleSize !== undefined && visibleSize !== (size as number)
+              {visibleSize != null && visibleSize !== (size as number)
                 ? translate('ITEMS_FILTERED', nodeData, {
                     visible: visibleSize,
                     total: size as number,

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -9,7 +9,6 @@ import {
   type ValueData,
 } from './types'
 import { Icon } from './Icons'
-import { filterNode } from './utils/filter'
 import { getModifier, insertCharInTextArea } from './utils/keyboard'
 import { isCollection, NOOP } from './utils/misc'
 import { AutogrowTextArea } from './AutogrowTextArea'
@@ -21,6 +20,8 @@ import {
   useCollapse,
   useAppliedBroadcast,
   useReferenceChanged,
+  useNodeVisible,
+  useVisibleChildCount,
 } from './contexts'
 import { isDescendantOf } from './utils/pathTools'
 import { areNodePropsEqual } from './utils/memoNode'
@@ -44,8 +45,6 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
     allowClipboard,
     onCopy,
     showIconTooltips,
-    searchFilter,
-    searchText,
     indent,
     sort,
     showArrayIndexes,
@@ -210,9 +209,13 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
   // For when children are accessed via Tab
   if (childrenEditing && collapsed) animateCollapse(false)
 
-  // Early return if this node is filtered out
-  const isVisible =
-    filterNode('collection', nodeData, searchFilter, searchText) || nodeData.level === 0
+  // Early return if this node is filtered out. Root (level 0) is always kept
+  // — the editor's outer container still needs to render even when nothing
+  // matches, so the user sees an "empty" tree rather than nothing at all.
+  const isVisible = useNodeVisible(path) || nodeData.level === 0
+  // Visible direct-child count when search is active; `null` otherwise.
+  // Powers the "n of m" filtered-count display below.
+  const visibleSize = useVisibleChildCount(path)
   if (!isVisible && !childrenEditing) return null
 
   const collectionType = Array.isArray(data) ? 'array' : 'object'
@@ -339,7 +342,15 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
   }
 
   const showLabel = showArrayIndexes || !isArray
-  const showCount = showCollectionCount === 'when-closed' ? collapsed : showCollectionCount
+  // `'when-closed-or-filtered'` surfaces the count whenever the filter is
+  // currently subsetting this collection's children — `visibleSize !== null`
+  // means search is active (the FilterStateProvider returns null otherwise).
+  const showCount =
+    showCollectionCount === 'when-closed'
+      ? collapsed
+      : showCollectionCount === 'when-closed-or-filtered'
+        ? collapsed || visibleSize !== null
+        : showCollectionCount
   const showEditButtons = !isEditing && showEditTools
   const shouldShowKey = showLabel && showKey && name !== undefined
   const showCustomNodeContents =
@@ -590,9 +601,16 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
                 transitionBehavior: 'allow-discrete',
               }}
             >
-              {size === 1
-                ? translate('ITEM_SINGLE', { ...nodeData, size: 1 }, 1)
-                : translate('ITEMS_MULTIPLE', nodeData, size as number)}
+              {visibleSize !== null && visibleSize !== (size as number)
+                ? translate(
+                    'ITEMS_FILTERED',
+                    { ...nodeData, visibleSize },
+                    size as number,
+                    { visible: visibleSize, total: size as number }
+                  )
+                : size === 1
+                  ? translate('ITEM_SINGLE', { ...nodeData, size: 1 }, 1)
+                  : translate('ITEMS_MULTIPLE', nodeData, size as number)}
             </div>
           )}
           <div

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -21,7 +21,6 @@ import {
   useAppliedBroadcast,
   useReferenceChanged,
   useNodeVisible,
-  useVisibleChildCount,
 } from './contexts'
 import { isDescendantOf } from './utils/pathTools'
 import { areNodePropsEqual } from './utils/memoNode'
@@ -213,10 +212,11 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
   // — the editor's outer container still needs to render even when nothing
   // matches, so the user sees an "empty" tree rather than nothing at all.
   const isVisible = useNodeVisible(path) || nodeData.level === 0
-  // Visible direct-child count when search is active; `null` otherwise.
-  // Powers the "n of m" filtered-count display below.
-  const visibleSize = useVisibleChildCount(path)
   if (!isVisible && !childrenEditing) return null
+
+  // `visibleSize` is set by useCommon when a filter is active; undefined
+  // otherwise. Drives the "n of m" filtered-count display below.
+  const { visibleSize } = nodeData
 
   const collectionType = Array.isArray(data) ? 'array' : 'object'
   const brackets =
@@ -343,13 +343,13 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
 
   const showLabel = showArrayIndexes || !isArray
   // `'when-closed-or-filtered'` surfaces the count whenever the filter is
-  // currently subsetting this collection's children — `visibleSize !== null`
-  // means search is active (the FilterStateProvider returns null otherwise).
+  // currently subsetting this collection's children — useCommon sets
+  // `visibleSize` only while a filter is active.
   const showCount =
     showCollectionCount === 'when-closed'
       ? collapsed
       : showCollectionCount === 'when-closed-or-filtered'
-        ? collapsed || visibleSize !== null
+        ? collapsed || visibleSize !== undefined
         : showCollectionCount
   const showEditButtons = !isEditing && showEditTools
   const shouldShowKey = showLabel && showKey && name !== undefined
@@ -601,13 +601,11 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
                 transitionBehavior: 'allow-discrete',
               }}
             >
-              {visibleSize !== null && visibleSize !== (size as number)
-                ? translate(
-                    'ITEMS_FILTERED',
-                    { ...nodeData, visibleSize },
-                    size as number,
-                    { visible: visibleSize, total: size as number }
-                  )
+              {visibleSize !== undefined && visibleSize !== (size as number)
+                ? translate('ITEMS_FILTERED', nodeData, {
+                    visible: visibleSize,
+                    total: size as number,
+                  })
                 : size === 1
                   ? translate('ITEM_SINGLE', { ...nodeData, size: 1 }, 1)
                   : translate('ITEMS_MULTIPLE', nodeData, size as number)}

--- a/src/JsonEditor.tsx
+++ b/src/JsonEditor.tsx
@@ -11,7 +11,7 @@ import { extract } from './utils/extract'
 import { CollectionNode } from './CollectionNode'
 import { NativeSelect } from './NativeSelect'
 import { getFullKeyboardControlMap, handleKeyPress } from './utils/keyboard'
-import { matchNode, matchNodeKey } from './utils/filter'
+import { computeFilterState, matchNode, matchNodeKey } from './utils/filter'
 import { isCollection, NOOP, restoreUndefined, UNDEFINED } from './utils/misc'
 import {
   type CollectionData,
@@ -38,6 +38,7 @@ import {
   defaultTheme,
   useEditingStore,
   useCollapse,
+  FilterStateProvider,
 } from './contexts'
 import {
   type CommitPrimitives,
@@ -137,7 +138,7 @@ const Editor: React.FC<
   indent = 2,
   collapse = false,
   collapseAnimationTime = 300, // must be equivalent to CSS value
-  showCollectionCount = 'when-closed',
+  showCollectionCount = 'when-closed-or-filtered',
   allowEdit = true,
   allowDelete = true,
   allowAdd = true,
@@ -496,6 +497,19 @@ const Editor: React.FC<
   const allowDragFilter = useMemo(() => getFilterFunction(allowDrag), [allowDrag])
   const searchFilter = useMemo(() => getSearchFilter(searchFilterInput), [searchFilterInput])
 
+  // Whole-tree visibility + per-collection visible-child counts, computed
+  // once per (data, debouncedSearchText, searchFilter) change. Surfaced to
+  // nodes via FilterStateProvider — see src/contexts/FilterStateProvider.tsx.
+  // `null` when no filter is active (the consumer hooks fast-path).
+  const filterState = useMemo(
+    () => computeFilterState(nodeData, searchFilter, debouncedSearchText),
+    // `nodeData` is rebuilt every render from `data`/`rootName`, but the walk
+    // only depends on the underlying `data` reference. Listing `nodeData`
+    // would recompute on every render; we want it tied to actual inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [data, debouncedSearchText, searchFilter, rootName]
+  )
+
   const fullKeyboardControls = useMemo(
     () => getFullKeyboardControlMap(keyboardControls),
     [keyboardControls]
@@ -664,8 +678,6 @@ const Editor: React.FC<
     allowTypeSelection,
     allowDragFilter,
     canDragOnto: false, // can't drag onto outermost container
-    searchFilter,
-    searchText: debouncedSearchText,
     allowClipboard,
     onCopy: onCopyStable,
     sortKeys,
@@ -711,11 +723,13 @@ const Editor: React.FC<
       className={`jer-editor-container ${className ?? ''}`}
       style={mainContainerStyles}
     >
-      {isCollection(data) && !customNodeData.renderCollectionAsValue ? (
-        <CollectionNode data={data} {...otherProps} />
-      ) : (
-        <ValueNodeWrapper data={data as ValueData} showLabel {...otherProps} />
-      )}
+      <FilterStateProvider value={filterState}>
+        {isCollection(data) && !customNodeData.renderCollectionAsValue ? (
+          <CollectionNode data={data} {...otherProps} />
+        ) : (
+          <ValueNodeWrapper data={data as ValueData} showLabel {...otherProps} />
+        )}
+      </FilterStateProvider>
     </div>
   )
 }

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -21,9 +21,14 @@ import {
   type EnumDefinition,
   type TabDirection,
 } from './types'
-import { useTheme, useEditingStore, useCollapse, type UpdateOutcome } from './contexts'
+import {
+  useTheme,
+  useEditingStore,
+  useCollapse,
+  useNodeVisible,
+  type UpdateOutcome,
+} from './contexts'
 import { buildCustomNodeData, type CustomNodeData } from './CustomNode'
-import { filterNode } from './utils/filter'
 import { pathsEqual } from './utils/pathTools'
 import { isJsEvent, matchEnumType, NOOP } from './utils/misc'
 import { useCommon, useDragNDrop } from './hooks'
@@ -39,8 +44,6 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
     onCopy,
     canDragOnto,
     allowTypeSelection,
-    searchFilter,
-    searchText,
     showLabel,
     stringTruncateLength,
     showStringQuotes,
@@ -179,7 +182,7 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
   const { isEditing, isPending } = derivedValues
 
   // Early return if this node is filtered out
-  const isVisible = filterNode('value', nodeData, searchFilter, searchText)
+  const isVisible = useNodeVisible(path)
 
   // Skip hidden or uneditable nodes that Tab navigation has landed on by
   // advancing the editing target to the next viable node.

--- a/src/contexts/FilterStateProvider.tsx
+++ b/src/contexts/FilterStateProvider.tsx
@@ -1,0 +1,69 @@
+/**
+ * Filter-state slice: surfaces the pre-computed `{ visiblePaths,
+ * visibleChildCounts }` from `JsonEditor` to every node, so per-node
+ * visibility/count is an O(1) Set/Map lookup instead of the per-node
+ * subtree walk the old `filterNode` did.
+ *
+ * Three consumer hooks:
+ *
+ *   useFilterActive()           — boolean: "is search active right now?"
+ *                                 Drives the n-of-m branch (no point
+ *                                 saying "5 of 5" when nothing's filtered).
+ *
+ *   useNodeVisible(path)        — boolean: "should this node render?"
+ *                                 Replaces both per-node `filterNode`
+ *                                 calls. Returns `true` when no filter
+ *                                 is active.
+ *
+ *   useVisibleChildCount(path)  — number | null: visible direct children
+ *                                 of this collection. `null` when no
+ *                                 filter is active (caller falls back to
+ *                                 `nodeData.size`).
+ *
+ * Pattern note: this is a dumb provider — `JsonEditor` owns the
+ * `useMemo` that builds the state, and passes it as a `value` prop.
+ * Keeps the algorithm out of React-land for testability (see
+ * `computeFilterState` in `utils/filter.ts`) and means the context
+ * value's identity is stable between search keystrokes (only changes
+ * when `(data, searchText, searchFilter)` change), so the §16 memo
+ * invariants hold for everything below.
+ */
+
+import React, { createContext, useContext } from 'react'
+import { type CollectionKey } from '../types'
+import { type FilterState } from '../utils/filter'
+import { toPathString } from '../utils/pathTools'
+
+// `null` value = no filter active. Distinct from `undefined` (= provider
+// missing); we throw on `undefined` in the hooks so a misuse outside the
+// editor surfaces loudly instead of silently returning "visible".
+const FilterStateContext = createContext<FilterState | null | undefined>(undefined)
+
+interface FilterStateProps {
+  value: FilterState | null
+  children: React.ReactNode
+}
+
+export const FilterStateProvider = ({ value, children }: FilterStateProps) => (
+  <FilterStateContext.Provider value={value}>{children}</FilterStateContext.Provider>
+)
+
+const useFilterStateContext = (): FilterState | null => {
+  const ctx = useContext(FilterStateContext)
+  if (ctx === undefined) throw new Error('Missing FilterStateProvider')
+  return ctx
+}
+
+export const useFilterActive = (): boolean => useFilterStateContext() !== null
+
+export const useNodeVisible = (path: CollectionKey[]): boolean => {
+  const fs = useFilterStateContext()
+  if (fs === null) return true
+  return fs.visiblePaths.has(toPathString(path))
+}
+
+export const useVisibleChildCount = (path: CollectionKey[]): number | null => {
+  const fs = useFilterStateContext()
+  if (fs === null) return null
+  return fs.visibleChildCounts.get(toPathString(path)) ?? 0
+}

--- a/src/contexts/FilterStateProvider.tsx
+++ b/src/contexts/FilterStateProvider.tsx
@@ -65,5 +65,8 @@ export const useNodeVisible = (path: CollectionKey[]): boolean => {
 export const useVisibleChildCount = (path: CollectionKey[]): number | null => {
   const fs = useFilterStateContext()
   if (fs === null) return null
-  return fs.visibleChildCounts.get(toPathString(path)) ?? 0
+  // `null` when this path has no entry — e.g. a leaf path, or a collection
+  // that wasn't walked. (A collection with zero matches has an entry of 0,
+  // which is meaningfully different.)
+  return fs.visibleChildCounts.get(toPathString(path)) ?? null
 }

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -3,3 +3,9 @@ export { TreeStateProvider } from './TreeStateProvider'
 export { useEditing, useEditingSelector, useEditingStore } from './EditingProvider'
 export type { UpdateOutcome } from './EditingProvider'
 export { useCollapse, useAppliedBroadcast, useReferenceChanged } from './CollapseProvider'
+export {
+  FilterStateProvider,
+  useFilterActive,
+  useNodeVisible,
+  useVisibleChildCount,
+} from './FilterStateProvider'

--- a/src/hooks/useCommon.ts
+++ b/src/hooks/useCommon.ts
@@ -43,11 +43,10 @@ export const useCommon = ({ props, collapsed }: CommonProps) => {
   const { submit, cancel } = useEditingStore()
   const [error, setError] = useState<string | null>(null)
 
-  const visibleSize = useVisibleChildCount(incomingNodeData.path)
   const nodeData = {
     ...incomingNodeData,
     collapsed,
-    ...(visibleSize !== null && { visibleSize }),
+    visibleSize: useVisibleChildCount(incomingNodeData.path),
   }
   const { path, key: name, size } = nodeData
 

--- a/src/hooks/useCommon.ts
+++ b/src/hooks/useCommon.ts
@@ -4,7 +4,7 @@
  */
 
 import React, { useCallback, useRef, useState } from 'react'
-import { useEditingSelector, useEditingStore } from '../contexts'
+import { useEditingSelector, useEditingStore, useVisibleChildCount } from '../contexts'
 import {
   type CollectionNodeProps,
   type ErrorString,
@@ -43,7 +43,12 @@ export const useCommon = ({ props, collapsed }: CommonProps) => {
   const { submit, cancel } = useEditingStore()
   const [error, setError] = useState<string | null>(null)
 
-  const nodeData = { ...incomingNodeData, collapsed }
+  const visibleSize = useVisibleChildCount(incomingNodeData.path)
+  const nodeData = {
+    ...incomingNodeData,
+    collapsed,
+    ...(visibleSize !== null && { visibleSize }),
+  }
   const { path, key: name, size } = nodeData
 
   const pathString = toPathString(path)

--- a/src/localisation.ts
+++ b/src/localisation.ts
@@ -3,6 +3,7 @@ import { type CustomTextDefinitions, type NodeData } from './types'
 const localisedStrings = {
   ITEM_SINGLE: '{{count}} item',
   ITEMS_MULTIPLE: '{{count}} items',
+  ITEMS_FILTERED: '{{visible}} of {{total}} items',
   KEY_NEW: 'Enter new key',
   KEY_SELECT: 'Select key',
   NO_KEY_OPTIONS: 'No key options',
@@ -26,7 +27,8 @@ export type LocalisedStrings = typeof localisedStrings
 export type TranslateFunction = (
   key: keyof LocalisedStrings,
   customData: NodeData,
-  count?: number
+  count?: number,
+  tokens?: Record<string, string | number>
 ) => string
 
 const translate = (
@@ -34,21 +36,32 @@ const translate = (
   customText: CustomTextDefinitions,
   customTextData: NodeData,
   key: keyof LocalisedStrings,
-  count?: number
+  count?: number,
+  tokens?: Record<string, string | number>
 ): string => {
   if (customText[key]) {
     const output = customText[key](customTextData)
     if (output !== null) return output
   }
 
-  const string = key in translations ? (translations[key] as string) : localisedStrings[key]
-  return count === undefined ? string : string?.replace('{{count}}', String(count))
+  let string = key in translations ? (translations[key] as string) : localisedStrings[key]
+  if (count !== undefined) string = string?.replace('{{count}}', String(count))
+  if (tokens) {
+    for (const [token, value] of Object.entries(tokens)) {
+      string = string?.replace(`{{${token}}}`, String(value))
+    }
+  }
+  return string
 }
 
 export const getTranslateFunction = (
   translations: Partial<LocalisedStrings>,
   customText: CustomTextDefinitions
 ) => {
-  return (key: keyof LocalisedStrings, customTextData: NodeData, count?: number) =>
-    translate(translations, customText, customTextData, key, count)
+  return (
+    key: keyof LocalisedStrings,
+    customTextData: NodeData,
+    count?: number,
+    tokens?: Record<string, string | number>
+  ) => translate(translations, customText, customTextData, key, count, tokens)
 }

--- a/src/localisation.ts
+++ b/src/localisation.ts
@@ -1,4 +1,5 @@
 import { type CustomTextDefinitions, type NodeData } from './types'
+import { isObject } from './utils/misc'
 
 const localisedStrings = {
   ITEM_SINGLE: '{{count}} item',
@@ -27,8 +28,7 @@ export type LocalisedStrings = typeof localisedStrings
 export type TranslateFunction = (
   key: keyof LocalisedStrings,
   customData: NodeData,
-  count?: number,
-  tokens?: Record<string, string | number>
+  counts?: number | Record<string, string | number>
 ) => string
 
 const translate = (
@@ -36,8 +36,7 @@ const translate = (
   customText: CustomTextDefinitions,
   customTextData: NodeData,
   key: keyof LocalisedStrings,
-  count?: number,
-  tokens?: Record<string, string | number>
+  counts?: number | Record<string, string | number>
 ): string => {
   if (customText[key]) {
     const output = customText[key](customTextData)
@@ -45,8 +44,8 @@ const translate = (
   }
 
   let string = key in translations ? (translations[key] as string) : localisedStrings[key]
-  if (count !== undefined) string = string?.replace('{{count}}', String(count))
-  if (tokens) {
+  if (counts !== undefined) {
+    const tokens = isObject(counts) ? counts : { count: counts }
     for (const [token, value] of Object.entries(tokens)) {
       string = string?.replace(`{{${token}}}`, String(value))
     }
@@ -61,7 +60,6 @@ export const getTranslateFunction = (
   return (
     key: keyof LocalisedStrings,
     customTextData: NodeData,
-    count?: number,
-    tokens?: Record<string, string | number>
-  ) => translate(translations, customText, customTextData, key, count, tokens)
+    counts?: number | Record<string, string | number>
+  ) => translate(translations, customText, customTextData, key, counts)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -416,11 +416,15 @@ export interface NodeData<T = JsonData> {
   index: number
   value: JsonData
   size: number | null
-  // Visible direct-child count under the current search filter — only set
-  // on collection nodes whose count is being displayed as "n of m". Picked
-  // up by `customText.ITEMS_FILTERED` overrides that want the filtered
-  // count alongside the total (`size`).
-  visibleSize?: number
+  // Visible direct-child count under the current search filter. `number` on
+  // tracked collections while a filter is active; `null` on render-path
+  // NodeData when either no filter is active or this isn't a tracked
+  // collection (e.g. a leaf). `undefined` only when the NodeData wasn't
+  // built by the render path — i.e. the `searchFilter` callback (which the
+  // visibility walk invokes before counts are known) or NodeData built via
+  // `buildNodeData` for the editorRef handle / onCollapse / onEditEvent
+  // bridges. Consumers can use `!= null` to gate on "has a real count".
+  visibleSize?: number | null
   parentData: object | null
   fullData: T
   collapsed?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface JsonEditorProps<T = JsonData> {
   indent?: number
   collapse?: boolean | number | FilterFunction<T>
   collapseAnimationTime?: number // ms
-  showCollectionCount?: boolean | 'when-closed'
+  showCollectionCount?: boolean | 'when-closed' | 'when-closed-or-filtered'
   allowEdit?: boolean | FilterFunction<T>
   allowDelete?: boolean | FilterFunction<T>
   allowAdd?: boolean | FilterFunction<T>
@@ -291,10 +291,6 @@ export type SearchFilterFunction<T = JsonData> = (
   inputData: NodeData<T>,
   searchText: string
 ) => boolean
-export type SearchFilterInputFunction<T = JsonData> = (
-  inputData: Partial<NodeData<T>>,
-  searchText: string
-) => boolean
 export type NewKeyOptionsFunction<T = JsonData> = (input: NodeData<T>) => string[] | null | void
 
 export type CopyType = 'path' | 'value'
@@ -420,6 +416,11 @@ export interface NodeData<T = JsonData> {
   index: number
   value: JsonData
   size: number | null
+  // Visible direct-child count under the current search filter — only set
+  // on collection nodes whose count is being displayed as "n of m". Picked
+  // up by `customText.ITEMS_FILTERED` overrides that want the filtered
+  // count alongside the total (`size`).
+  visibleSize?: number
   parentData: object | null
   fullData: T
   collapsed?: boolean
@@ -444,8 +445,6 @@ interface BaseNodeProps {
   allowAddFilter: FilterFunction
   allowDragFilter: FilterFunction
   canDragOnto: boolean
-  searchFilter?: SearchFilterFunction
-  searchText?: string
   allowTypeSelection: boolean | TypeOptions | TypeFilterFunction
   stringTruncateLength: number
   indent: number
@@ -476,7 +475,7 @@ export interface CollectionNodeProps extends BaseNodeProps {
   collapseFilter: FilterFunction
   collapseAnimationTime: number
   showArrayIndexes: boolean
-  showCollectionCount: boolean | 'when-closed'
+  showCollectionCount: boolean | 'when-closed' | 'when-closed-or-filtered'
   showStringQuotes: boolean
   defaultValue: unknown
   newKeyOptions?: string[] | NewKeyOptionsFunction

--- a/src/utils/assign.ts
+++ b/src/utils/assign.ts
@@ -7,6 +7,7 @@
 // values (JSON, functions, etc.), and `unknown` would force callers to
 // narrow before passing.
 
+import { isObject } from './misc'
 import { splitPropertyString, stringifyPath, type Path } from './pathTools'
 
 type BasicType = string | number | boolean | undefined | null | ((...args: unknown[]) => unknown)
@@ -46,9 +47,6 @@ const maybeThrow = (
     )
   return
 }
-
-const isObject = (input: unknown): input is InputObject =>
-  typeof input === 'object' && input !== null && !Array.isArray(input)
 
 const isArray = (input: unknown): input is Array<Value> => Array.isArray(input)
 

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,66 +1,92 @@
-import {
-  type NodeData,
-  type SearchFilterFunction,
-  type SearchFilterInputFunction,
-} from '../types'
+import { type NodeData, type SearchFilterFunction } from '../types'
 import { isCollection } from './misc'
+import { toPathString } from './pathTools'
 
 /**
- * Handles the overall logic for whether a node should be visible or not, and
- * returns true/false accordingly. Collections must be handled differently to
- * primitive values, as they must also check their children (recursively)
+ * Pre-computed visibility state for the whole tree under a given search.
+ * Produced once at the JsonEditor level (see `computeFilterState` below)
+ * and surfaced to nodes via the `FilterStateProvider` context slice.
+ *
+ *  - `visiblePaths` — every node whose own match or whose descendant's
+ *    match keeps it on screen (ancestors of a matching node stay visible).
+ *  - `visibleChildCounts` — for every collection node, how many of its
+ *    direct children are visible. Powers the "n of m" filtered-count
+ *    display.
+ *
+ * Keys are produced by `toPathString` so they're stable, collision-free,
+ * and cheap to look up.
  */
-export const filterNode = (
-  type: 'collection' | 'value',
-  nodeData: NodeData,
-  searchFilter: SearchFilterFunction | undefined,
-  searchText: string | undefined = ''
-): boolean => {
-  if (!searchFilter && !searchText) return true
-
-  switch (type) {
-    case 'collection':
-      if (searchFilter) {
-        if (searchFilter(nodeData, searchText)) return true
-        if (!filterCollection(searchText, nodeData, searchFilter)) return false
-      }
-      if (!searchFilter && searchText && !filterCollection(searchText, nodeData)) return false
-      break
-    case 'value':
-      if (searchFilter && !searchFilter(nodeData, searchText)) return false
-      if (!searchFilter && searchText && !matchNode(nodeData, searchText)) return false
-  }
-
-  return true
+export interface FilterState {
+  visiblePaths: Set<string>
+  visibleChildCounts: Map<string, number>
 }
 
-// Each collection must recursively check the matches of all its descendants --
-// if a deeply nested node matches the searchFilter, then all it's ancestors
-// must also remain visible
-const filterCollection = (
-  searchText: string = '',
-  nodeData: NodeData,
-  matcher: SearchFilterInputFunction | SearchFilterFunction = matchNode
-): boolean => {
-  const collection = nodeData.value as object | unknown[]
-  const entries = Object.entries(collection)
+/**
+ * Single post-order DFS that decides which nodes stay visible under the
+ * current search, and counts the visible direct children of every
+ * collection along the way. Returns `null` when no filter is active — the
+ * caller fast-paths to "everything visible, use raw `size`".
+ *
+ * Replaces the old per-CollectionNode `filterNode`/`filterCollection`
+ * pair, which independently re-walked every visible collection's subtree.
+ * That cost ~O(n × depth); this is O(n). The redundancy multiplier the
+ * previous approach paid grew with depth — measured ~4× on balanced
+ * trees, ~11× on deep trees in the filter bench.
+ *
+ * Also fixes a real correctness bug in the old approach:
+ * `filterCollection` recursed into child collections without first
+ * testing the child's own matcher, so an intermediate collection whose
+ * key matched but whose body was empty (or whose descendants weren't
+ * path-aware-matched) would drop out and drag its ancestors with it. The
+ * walk here tests every node, including intermediate collections.
+ */
+export const computeFilterState = (
+  rootNodeData: NodeData,
+  searchFilter: SearchFilterFunction | undefined,
+  searchText: string | undefined
+): FilterState | null => {
+  if (!searchFilter && !searchText) return null
 
-  return entries.some(([key, value]) => {
-    const childPath = [...nodeData.path, key]
+  const visiblePaths = new Set<string>()
+  const visibleChildCounts = new Map<string, number>()
+  // Match the editor's default-matcher rule: when no searchFilter is
+  // given but searchText is set, fall back to the per-value matcher.
+  // Same as the old filterNode's value branch did.
+  const matcher = searchFilter ?? matchNode
+  const text = searchText ?? ''
 
-    const childNodeData = {
-      ...nodeData,
-      key,
-      path: childPath,
-      level: nodeData.level + 1,
-      value,
-      size: childPath.length,
-      parentData: collection,
+  const walk = (nd: NodeData): boolean => {
+    let matched = matcher(nd, text)
+    if (isCollection(nd.value)) {
+      let visibleChildren = 0
+      const isArr = Array.isArray(nd.value)
+      const entries = Object.entries(nd.value as object)
+      for (const [key, value] of entries) {
+        const childKey = isArr ? Number(key) : key
+        const childPath = [...nd.path, childKey]
+        const childNd: NodeData = {
+          key: childKey,
+          path: childPath,
+          level: nd.level + 1,
+          index: visibleChildren,
+          value,
+          size: isCollection(value) ? Object.keys(value as object).length : null,
+          parentData: nd.value as object,
+          fullData: nd.fullData,
+        }
+        if (walk(childNd)) {
+          matched = true
+          visibleChildren++
+        }
+      }
+      visibleChildCounts.set(toPathString(nd.path), visibleChildren)
     }
-    if (isCollection(value)) return filterCollection(searchText, childNodeData, matcher)
+    if (matched) visiblePaths.add(toPathString(nd.path))
+    return matched
+  }
 
-    return matcher(childNodeData, searchText)
-  })
+  walk(rootNodeData)
+  return { visiblePaths, visibleChildCounts }
 }
 
 export const matchNode: (input: Partial<NodeData>, searchText: string) => boolean = (

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -24,21 +24,8 @@ export interface FilterState {
 /**
  * Single post-order DFS that decides which nodes stay visible under the
  * current search, and counts the visible direct children of every
- * collection along the way. Returns `null` when no filter is active — the
- * caller fast-paths to "everything visible, use raw `size`".
- *
- * Replaces the old per-CollectionNode `filterNode`/`filterCollection`
- * pair, which independently re-walked every visible collection's subtree.
- * That cost ~O(n × depth); this is O(n). The redundancy multiplier the
- * previous approach paid grew with depth — measured ~4× on balanced
- * trees, ~11× on deep trees in the filter bench.
- *
- * Also fixes a real correctness bug in the old approach:
- * `filterCollection` recursed into child collections without first
- * testing the child's own matcher, so an intermediate collection whose
- * key matched but whose body was empty (or whose descendants weren't
- * path-aware-matched) would drop out and drag its ancestors with it. The
- * walk here tests every node, including intermediate collections.
+ * collection along the way. Returns `null` when no filter is active —
+ * the caller fast-paths to "everything visible, use raw `size`".
  */
 export const computeFilterState = (
   rootNodeData: NodeData,
@@ -60,7 +47,7 @@ export const computeFilterState = (
     if (isCollection(nd.value)) {
       let visibleChildren = 0
       const isArr = Array.isArray(nd.value)
-      const entries = Object.entries(nd.value as object)
+      const entries = Object.entries(nd.value)
       for (const [key, value] of entries) {
         const childKey = isArr ? Number(key) : key
         const childPath = [...nd.path, childKey]
@@ -70,8 +57,8 @@ export const computeFilterState = (
           level: nd.level + 1,
           index: visibleChildren,
           value,
-          size: isCollection(value) ? Object.keys(value as object).length : null,
-          parentData: nd.value as object,
+          size: isCollection(value) ? Object.keys(value).length : null,
+          parentData: nd.value,
           fullData: nd.fullData,
         }
         if (walk(childNd)) {

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -14,6 +14,9 @@ export const NOOP = () => {}
 export const isCollection = (value: unknown): value is Record<string, unknown> | unknown[] =>
   value !== null && typeof value === 'object'
 
+export const isObject = (input: unknown): input is Record<string, unknown> =>
+  typeof input === 'object' && input !== null && !Array.isArray(input)
+
 export const isJsEvent = (value: unknown) => {
   return (
     value &&

--- a/test/JsonEditor.test.tsx
+++ b/test/JsonEditor.test.tsx
@@ -1928,6 +1928,105 @@ describe('JsonEditor — search and filter', () => {
       jest.useRealTimers()
     }
   })
+
+  test('showCollectionCount: renders "n of m" when search filters out some children', () => {
+    // 5 items in the array, but only 2 contain 'apple'. Force the count to
+    // be visible regardless of collapse state with showCollectionCount={true}.
+    render(
+      <JsonEditor
+        data={{ items: ['apple-1', 'banana', 'apple-pie', 'cherry', 'plum'] }}
+        setData={noop}
+        searchText="apple"
+        showCollectionCount
+      />
+    )
+    expect(screen.getByText('2 of 5 items')).toBeInTheDocument()
+  })
+
+  test('customText.ITEMS_FILTERED can suppress the n-of-m form entirely', () => {
+    // The documented escape hatch for "always show the total under search":
+    // override ITEMS_FILTERED to return the same form ITEMS_MULTIPLE would.
+    render(
+      <JsonEditor
+        data={{ items: ['apple-1', 'banana', 'apple-pie', 'cherry', 'plum'] }}
+        setData={noop}
+        searchText="apple"
+        showCollectionCount
+        customText={{
+          ITEMS_FILTERED: ({ size }) => `${size} items`,
+        }}
+      />
+    )
+    expect(screen.getByText('5 items')).toBeInTheDocument()
+    expect(screen.queryByText('2 of 5 items')).toBeNull()
+  })
+
+  test('"when-closed-or-filtered" surfaces the count on an open node under search', () => {
+    // The default behaviour: even on an open collection (where the count
+    // would normally hide), search activates the count display so n-of-m
+    // is visible without forcing the user to collapse. The count element
+    // is always in the DOM (for CSS fade transitions); visibility is the
+    // .jer-visible / .jer-hidden class.
+    render(
+      <JsonEditor
+        data={{ items: ['apple-1', 'banana', 'apple-pie', 'cherry', 'plum'] }}
+        setData={noop}
+        searchText="apple"
+        // showCollectionCount left at default ('when-closed-or-filtered')
+        collapse={false}
+      />
+    )
+    const countEl = screen.getByText('2 of 5 items')
+    expect(countEl).toHaveClass('jer-visible')
+    expect(countEl).not.toHaveClass('jer-hidden')
+  })
+
+  test('"when-closed" suppresses the count on an open node, even under search', () => {
+    // Opt-out of the filtered-aware default — counts only appear when the
+    // collection is collapsed, regardless of search state.
+    render(
+      <JsonEditor
+        data={{ items: ['apple-1', 'banana', 'apple-pie', 'cherry', 'plum'] }}
+        setData={noop}
+        searchText="apple"
+        showCollectionCount="when-closed"
+        collapse={false}
+      />
+    )
+    const countEl = screen.getByText('2 of 5 items')
+    expect(countEl).toHaveClass('jer-hidden')
+    expect(countEl).not.toHaveClass('jer-visible')
+  })
+
+  test('"n of m" reverts to the simple total when search matches all children', () => {
+    // Every child contains 'a' → visible === total → no "of" form.
+    render(
+      <JsonEditor
+        data={{ items: ['apple', 'banana', 'avocado'] }}
+        setData={noop}
+        searchText="a"
+        showCollectionCount
+      />
+    )
+    expect(screen.getByText('3 items')).toBeInTheDocument()
+    expect(screen.queryByText(/3 of 3 items/)).toBeNull()
+  })
+
+  test('"n of m" customText override receives both `size` and `visibleSize`', () => {
+    render(
+      <JsonEditor
+        data={{ items: ['apple-1', 'banana', 'apple-pie', 'cherry', 'plum'] }}
+        setData={noop}
+        searchText="apple"
+        showCollectionCount
+        customText={{
+          ITEMS_FILTERED: ({ size, visibleSize }) =>
+            `[${visibleSize}/${size}] match`,
+        }}
+      />
+    )
+    expect(screen.getByText('[2/5] match')).toBeInTheDocument()
+  })
 })
 
 describe('JsonEditor — textarea character insertion via keyboard', () => {

--- a/test/JsonEditor.test.tsx
+++ b/test/JsonEditor.test.tsx
@@ -2027,6 +2027,54 @@ describe('JsonEditor — search and filter', () => {
     )
     expect(screen.getByText('[2/5] match')).toBeInTheDocument()
   })
+
+  test('`visibleSize` reaches render-path callbacks: number on tracked collections, `null` on visible leaves', () => {
+    // Locks in the D11 universal-exposure contract for callbacks that run
+    // AFTER the visibility walk (allowEdit, theme functions, customText,
+    // custom-node conditions, etc.). They see the `useCommon`-augmented
+    // NodeData with `visibleSize` set.
+    const seen = new Map<string, number | null | undefined>()
+    render(
+      <JsonEditor
+        data={{ outer: { inner: ['apple-1', 'banana'] } }}
+        setData={noop}
+        searchText="apple"
+        allowEdit={(nodeData) => {
+          seen.set(nodeData.path.join('/') || 'ROOT', nodeData.visibleSize)
+          return true
+        }}
+      />
+    )
+    // Tracked collections under an active filter: `visibleSize` is a number.
+    expect(typeof seen.get('ROOT')).toBe('number')
+    expect(typeof seen.get('outer')).toBe('number')
+    expect(typeof seen.get('outer/inner')).toBe('number')
+    // Leaf paths aren't in `visibleChildCounts`, so they get `null` —
+    // even the filtered-out 'banana', whose useCommon (and so its
+    // allowEdit invocation) still runs before the visibility early-return.
+    expect(seen.get('outer/inner/0')).toBeNull() // 'apple-1', matches
+    expect(seen.get('outer/inner/1')).toBeNull() // 'banana', doesn't match
+  })
+
+  test('`visibleSize` is `null` on render-path NodeData when no filter is active', () => {
+    // Outside a filter, the FilterStateProvider's value is `null`, the
+    // hook returns `null`, and useCommon spreads `visibleSize: null` onto
+    // every render-path NodeData. (`undefined` would mean "NodeData built
+    // outside the render path", which doesn't apply here.)
+    const seen: (number | null | undefined)[] = []
+    render(
+      <JsonEditor
+        data={{ outer: { inner: 'leaf' } }}
+        setData={noop}
+        allowEdit={(nodeData) => {
+          seen.push(nodeData.visibleSize)
+          return true
+        }}
+      />
+    )
+    expect(seen.length).toBeGreaterThan(0)
+    seen.forEach((v) => expect(v).toBeNull())
+  })
 })
 
 describe('JsonEditor — textarea character insertion via keyboard', () => {

--- a/test/filter-bug.test.tsx
+++ b/test/filter-bug.test.tsx
@@ -1,23 +1,26 @@
 /**
- * Regression repros for the bug surfaced in dev-docs/search_analysis.md §10
- * (and v2-filtered-collection-count.md):
+ * Regression guards for the search/filter bug originally documented in
+ * dev-docs/search_analysis.md §10 (and v2-filtered-collection-count.md):
  *
- *   filterCollection (src/utils/filter.ts) recurses into a child collection
- *   *without* first testing the child's own matcher. So a collection whose
- *   key would match but whose body is empty (or whose descendants don't
- *   match) drops out, dragging all its ancestors with it.
+ *   The old filterCollection recursed into a child collection *without*
+ *   first testing the child's own matcher. So an intermediate collection
+ *   whose key matched but whose body was empty (or whose descendants
+ *   weren't path-aware-matched) dropped out and dragged its ancestors
+ *   with it.
  *
- * Concrete repro: { rootContainer: { interestingThing: {} } } + searchFilter
- * 'key' + searchText 'interestingThing'. The user types a literal key from
- * the data and sees nothing. See the markdown for the full trace.
+ * Concrete repro: { rootContainer: { interestingThing: {} } } +
+ * searchFilter 'key' + searchText 'interestingThing'. Before the fix,
+ * the user typed a literal key from the data and saw nothing.
  *
- * Tests use `test.failing` so today's suite stays green; remove `.failing`
- * once the single-pass walk fix lands and these flip into regression guards.
+ * The single-pass walk in `computeFilterState` (src/utils/filter.ts)
+ * tests every node, including intermediate collections, so this case
+ * stays visible.
  */
 
 import { render, screen } from '@testing-library/react'
 import { JsonEditor } from '../src/JsonEditor'
-import { filterNode, matchNodeKey } from '../src/utils/filter'
+import { computeFilterState, matchNodeKey } from '../src/utils/filter'
+import { toPathString } from '../src/utils/pathTools'
 import type { NodeData } from '../src/types'
 
 const buildNd = (overrides: Partial<NodeData> & Pick<NodeData, 'value'>): NodeData => ({
@@ -31,28 +34,23 @@ const buildNd = (overrides: Partial<NodeData> & Pick<NodeData, 'value'>): NodeDa
   ...overrides,
 })
 
-describe('filterCollection — intermediate collection match is missed', () => {
-  test.failing(
-    'unit: ancestor stays visible when a descendant key matches but its body is empty',
-    () => {
-      const data = { rootContainer: { interestingThing: {} } }
-      const rootContainerNd = buildNd({
-        key: 'rootContainer',
-        path: ['rootContainer'],
-        level: 1,
-        value: data.rootContainer,
-        size: 1,
-        parentData: data,
-        fullData: data,
-      })
-      // Today this returns false: filterCollection recurses into
-      // { interestingThing: {} }, then into {}, hits [].some(...) → false,
-      // and never tests matchNodeKey on 'interestingThing' itself.
-      expect(filterNode('collection', rootContainerNd, matchNodeKey, 'interestingThing')).toBe(true)
-    }
-  )
+describe('regression: intermediate collection match is preserved', () => {
+  test('unit: ancestor stays visible when a key matches but the body is empty', () => {
+    const data = { rootContainer: { interestingThing: {} } }
+    const rootNd = buildNd({
+      value: data,
+      size: 1,
+      fullData: data,
+    })
+    const fs = computeFilterState(rootNd, matchNodeKey, 'interestingThing')!
+    expect(fs).not.toBeNull()
+    // The matching node itself stays visible…
+    expect(fs.visiblePaths.has(toPathString(['rootContainer', 'interestingThing']))).toBe(true)
+    // …and so does its ancestor, otherwise the matching node never renders.
+    expect(fs.visiblePaths.has(toPathString(['rootContainer']))).toBe(true)
+  })
 
-  test.failing('render: the matching key is reachable in the DOM', () => {
+  test('render: the matching key is reachable in the DOM', () => {
     const data = { rootContainer: { interestingThing: {} } }
     render(
       <JsonEditor
@@ -63,34 +61,29 @@ describe('filterCollection — intermediate collection match is missed', () => {
         collapse={false}
       />
     )
-    // Today rootContainer is filtered out → interestingThing never renders.
-    // After the fix it should be on screen.
     expect(screen.queryByText('interestingThing')).not.toBeNull()
   })
 
-  test.failing(
-    'render: a custom searchFilter that only inspects `key` still surfaces an intermediate match',
-    () => {
-      // The built-in matchNodeKey accidentally papers over the bug in many
-      // cases because it checks the FULL PATH: deep leaves under a matching
-      // key inherit the match via their path. A custom filter that only looks
-      // at `key` (no path) doesn't get that rescue, so the bug manifests even
-      // with a non-empty body.
-      const data = {
-        rootContainer: {
-          interestingThing: { unrelatedChild: 'plain-value' },
-        },
-      }
-      render(
-        <JsonEditor
-          data={data}
-          setData={() => {}}
-          searchFilter={(nodeData, searchText) => String(nodeData.key) === searchText}
-          searchText="interestingThing"
-          collapse={false}
-        />
-      )
-      expect(screen.queryByText('interestingThing')).not.toBeNull()
+  test('render: a custom searchFilter that only inspects `key` still surfaces an intermediate match', () => {
+    // The built-in matchNodeKey accidentally papered over the bug in many
+    // cases because it checks the FULL PATH: deep leaves under a matching
+    // key inherited the match via their path. A custom filter that only
+    // looks at `key` (no path) doesn't get that rescue — this case used
+    // to fail even with a non-empty body.
+    const data = {
+      rootContainer: {
+        interestingThing: { unrelatedChild: 'plain-value' },
+      },
     }
-  )
+    render(
+      <JsonEditor
+        data={data}
+        setData={() => {}}
+        searchFilter={(nodeData, searchText) => String(nodeData.key) === searchText}
+        searchText="interestingThing"
+        collapse={false}
+      />
+    )
+    expect(screen.queryByText('interestingThing')).not.toBeNull()
+  })
 })

--- a/test/filter-bug.test.tsx
+++ b/test/filter-bug.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Regression repros for the bug surfaced in dev-docs/search_analysis.md §10
+ * (and v2-filtered-collection-count.md):
+ *
+ *   filterCollection (src/utils/filter.ts) recurses into a child collection
+ *   *without* first testing the child's own matcher. So a collection whose
+ *   key would match but whose body is empty (or whose descendants don't
+ *   match) drops out, dragging all its ancestors with it.
+ *
+ * Concrete repro: { rootContainer: { interestingThing: {} } } + searchFilter
+ * 'key' + searchText 'interestingThing'. The user types a literal key from
+ * the data and sees nothing. See the markdown for the full trace.
+ *
+ * Tests use `test.failing` so today's suite stays green; remove `.failing`
+ * once the single-pass walk fix lands and these flip into regression guards.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { JsonEditor } from '../src/JsonEditor'
+import { filterNode, matchNodeKey } from '../src/utils/filter'
+import type { NodeData } from '../src/types'
+
+const buildNd = (overrides: Partial<NodeData> & Pick<NodeData, 'value'>): NodeData => ({
+  key: '',
+  path: [],
+  level: 0,
+  index: 0,
+  size: null,
+  parentData: null,
+  fullData: overrides.value,
+  ...overrides,
+})
+
+describe('filterCollection — intermediate collection match is missed', () => {
+  test.failing(
+    'unit: ancestor stays visible when a descendant key matches but its body is empty',
+    () => {
+      const data = { rootContainer: { interestingThing: {} } }
+      const rootContainerNd = buildNd({
+        key: 'rootContainer',
+        path: ['rootContainer'],
+        level: 1,
+        value: data.rootContainer,
+        size: 1,
+        parentData: data,
+        fullData: data,
+      })
+      // Today this returns false: filterCollection recurses into
+      // { interestingThing: {} }, then into {}, hits [].some(...) → false,
+      // and never tests matchNodeKey on 'interestingThing' itself.
+      expect(filterNode('collection', rootContainerNd, matchNodeKey, 'interestingThing')).toBe(true)
+    }
+  )
+
+  test.failing('render: the matching key is reachable in the DOM', () => {
+    const data = { rootContainer: { interestingThing: {} } }
+    render(
+      <JsonEditor
+        data={data}
+        setData={() => {}}
+        searchFilter="key"
+        searchText="interestingThing"
+        collapse={false}
+      />
+    )
+    // Today rootContainer is filtered out → interestingThing never renders.
+    // After the fix it should be on screen.
+    expect(screen.queryByText('interestingThing')).not.toBeNull()
+  })
+
+  test.failing(
+    'render: a custom searchFilter that only inspects `key` still surfaces an intermediate match',
+    () => {
+      // The built-in matchNodeKey accidentally papers over the bug in many
+      // cases because it checks the FULL PATH: deep leaves under a matching
+      // key inherit the match via their path. A custom filter that only looks
+      // at `key` (no path) doesn't get that rescue, so the bug manifests even
+      // with a non-empty body.
+      const data = {
+        rootContainer: {
+          interestingThing: { unrelatedChild: 'plain-value' },
+        },
+      }
+      render(
+        <JsonEditor
+          data={data}
+          setData={() => {}}
+          searchFilter={(nodeData, searchText) => String(nodeData.key) === searchText}
+          searchText="interestingThing"
+          collapse={false}
+        />
+      )
+      expect(screen.queryByText('interestingThing')).not.toBeNull()
+    }
+  )
+})

--- a/test/filter-bug.test.tsx
+++ b/test/filter-bug.test.tsx
@@ -1,20 +1,13 @@
 /**
- * Regression guards for the search/filter bug originally documented in
- * dev-docs/search_analysis.md §10 (and v2-filtered-collection-count.md):
+ * Prevents a possible bug where an intermediate collection whose key
+ * matches the search filter but whose body has no path-aware-matched
+ * descendants (e.g. an empty `{}`, or any subtree under a custom
+ * `searchFilter` that doesn't consult `path`) drops out of the visible
+ * set and drags its ancestors with it.
  *
- *   The old filterCollection recursed into a child collection *without*
- *   first testing the child's own matcher. So an intermediate collection
- *   whose key matched but whose body was empty (or whose descendants
- *   weren't path-aware-matched) dropped out and dragged its ancestors
- *   with it.
- *
- * Concrete repro: { rootContainer: { interestingThing: {} } } +
- * searchFilter 'key' + searchText 'interestingThing'. Before the fix,
- * the user typed a literal key from the data and saw nothing.
- *
- * The single-pass walk in `computeFilterState` (src/utils/filter.ts)
- * tests every node, including intermediate collections, so this case
- * stays visible.
+ * Concrete repro: `{ rootContainer: { interestingThing: {} } }` +
+ * `searchFilter: 'key'` + `searchText: 'interestingThing'`. The user
+ * types a literal key from the data; the matching key must be reachable.
  */
 
 import { render, screen } from '@testing-library/react'

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -218,5 +218,21 @@ describe('computeFilterState', () => {
     expect(fs.visibleChildCounts.get(toPathString(['a']))).toBe(1)
     expect(fs.visibleChildCounts.get(toPathString([]))).toBe(1)
   })
+
+  test('visibleChildCounts has no entry for leaf paths', () => {
+    // The `useVisibleChildCount` hook relies on this to distinguish "tracked
+    // collection with 0 matches" (entry present, value 0) from "leaf or
+    // untracked path" (no entry — hook returns null, not 0). Without this
+    // distinction, every leaf during filter-active would get a spurious
+    // `visibleSize: 0` on its NodeData.
+    const data = { fruits: ['apple', 'banana'], note: 'plain' }
+    const fs = computeFilterState(root(data), undefined, 'apple')!
+    // The leaf `note` matched nothing — but it's a leaf, so no entry.
+    expect(fs.visibleChildCounts.has(toPathString(['note']))).toBe(false)
+    // The leaf `fruits[0]` (which DID match) — still no entry, it's a leaf.
+    expect(fs.visibleChildCounts.has(toPathString(['fruits', 0]))).toBe(false)
+    // The collection `fruits` (one match out of two) — entry present.
+    expect(fs.visibleChildCounts.get(toPathString(['fruits']))).toBe(1)
+  })
 })
 

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -1,5 +1,6 @@
-import { matchNode, matchNodeKey } from '../src/utils/filter'
-import type { NodeData } from '../src/types'
+import { computeFilterState, matchNode, matchNodeKey } from '../src/utils/filter'
+import { toPathString } from '../src/utils/pathTools'
+import type { JsonData, NodeData, SearchFilterFunction } from '../src/types'
 
 describe('matchNode', () => {
   describe('strings', () => {
@@ -125,6 +126,97 @@ describe('matchNodeKey', () => {
   test('case-insensitive (inherited from matchNode)', () => {
     expect(matchNodeKey(node('UserName', ['user', 'UserName']), 'username')).toBe(true)
     expect(matchNodeKey(node('x', ['ROOT', 'x']), 'root')).toBe(true)
+  })
+})
+
+describe('computeFilterState', () => {
+  const root = (data: JsonData): NodeData => ({
+    key: '',
+    path: [],
+    level: 0,
+    index: 0,
+    value: data,
+    size:
+      typeof data === 'object' && data !== null ? Object.keys(data as object).length : null,
+    parentData: null,
+    fullData: data,
+  })
+
+  test('returns null when no filter is active', () => {
+    expect(computeFilterState(root({ a: 1 }), undefined, '')).toBeNull()
+    expect(computeFilterState(root({ a: 1 }), undefined, undefined)).toBeNull()
+  })
+
+  test('value match: ancestors of a matching leaf stay visible', () => {
+    const data = { user: { profile: { name: 'Alice', age: 30 } } }
+    const fs = computeFilterState(root(data), undefined, 'Alic')!
+    expect(fs).not.toBeNull()
+    expect(fs.visiblePaths.has(toPathString(['user', 'profile', 'name']))).toBe(true)
+    expect(fs.visiblePaths.has(toPathString(['user', 'profile']))).toBe(true)
+    expect(fs.visiblePaths.has(toPathString(['user']))).toBe(true)
+    expect(fs.visiblePaths.has(toPathString([]))).toBe(true)
+    // The sibling 'age' doesn't match → not visible.
+    expect(fs.visiblePaths.has(toPathString(['user', 'profile', 'age']))).toBe(false)
+  })
+
+  test('counts only direct visible children (not all descendants)', () => {
+    const data = {
+      fruits: { apple: 'red', banana: 'yellow', cherry: 'red' },
+      tools: { hammer: 'metal', drill: 'electric' },
+    }
+    // 'red' matches apple + cherry under fruits; nothing under tools matches.
+    const fs = computeFilterState(root(data), undefined, 'red')!
+    expect(fs.visibleChildCounts.get(toPathString(['fruits']))).toBe(2)
+    expect(fs.visibleChildCounts.get(toPathString(['tools']))).toBe(0)
+    // Root has one visible direct child (fruits); tools is hidden.
+    expect(fs.visibleChildCounts.get(toPathString([]))).toBe(1)
+  })
+
+  test('matchNodeKey: a matching key on an empty collection keeps ancestors visible', () => {
+    // This is the bug repro from filter-bug.test.tsx, now expressed against
+    // computeFilterState. The old filterCollection short-circuited to false
+    // on an empty body and silently hid the matching ancestor.
+    const data = { rootContainer: { interestingThing: {} } }
+    const fs = computeFilterState(root(data), matchNodeKey, 'interestingThing')!
+    expect(fs.visiblePaths.has(toPathString(['rootContainer', 'interestingThing']))).toBe(true)
+    expect(fs.visiblePaths.has(toPathString(['rootContainer']))).toBe(true)
+  })
+
+  test('custom searchFilter that ignores path: intermediate match keeps ancestors visible', () => {
+    // The previous filterCollection only ever tested LEAVES via the matcher
+    // — intermediate collections were recursed into, never matched on
+    // directly. A key-only custom filter never had a chance.
+    const data = {
+      rootContainer: { interestingThing: { unrelatedChild: 'plain-value' } },
+    }
+    const keyOnly: SearchFilterFunction = (nd, st) => String(nd.key) === st
+    const fs = computeFilterState(root(data), keyOnly, 'interestingThing')!
+    expect(fs.visiblePaths.has(toPathString(['rootContainer', 'interestingThing']))).toBe(true)
+    expect(fs.visiblePaths.has(toPathString(['rootContainer']))).toBe(true)
+  })
+
+  test('arrays: keys are numeric in path and child node data', () => {
+    const data = { items: ['apple', 'banana', 'cherry'] }
+    const fs = computeFilterState(root(data), undefined, 'banana')!
+    // Path uses the numeric index for arrays.
+    expect(fs.visiblePaths.has(toPathString(['items', 1]))).toBe(true)
+    expect(fs.visibleChildCounts.get(toPathString(['items']))).toBe(1)
+  })
+
+  test('no-match search: every collection records 0 visible children, no path is visible', () => {
+    const data = { a: { b: 'hello' }, c: 'world' }
+    const fs = computeFilterState(root(data), undefined, 'zzz_no_match')!
+    expect(fs.visiblePaths.size).toBe(0)
+    expect(fs.visibleChildCounts.get(toPathString(['a']))).toBe(0)
+    expect(fs.visibleChildCounts.get(toPathString([]))).toBe(0)
+  })
+
+  test('records visibleChildCounts for every collection node, even nested ones', () => {
+    const data = { a: { b: { c: 'match-me' }, d: 'nope' } }
+    const fs = computeFilterState(root(data), undefined, 'match-me')!
+    expect(fs.visibleChildCounts.get(toPathString(['a', 'b']))).toBe(1)
+    expect(fs.visibleChildCounts.get(toPathString(['a']))).toBe(1)
+    expect(fs.visibleChildCounts.get(toPathString([]))).toBe(1)
   })
 })
 

--- a/test/perf/filter.bench.ts
+++ b/test/perf/filter.bench.ts
@@ -1,50 +1,46 @@
 /**
- * filterNode / filterCollection performance bench.
+ * `computeFilterState` performance bench.
  *
- * Two measurements per tree × search variant:
- *
- *   single   — one filterNode('collection', root, ...) call. This is the
- *              cost of computing whole-tree visibility once, i.e. what a
- *              hypothetical top-level precompute would pay.
- *   cascade  — call filterNode('collection', ...) at EVERY collection node
- *              in the tree, depth-first. This mirrors the work the editor
- *              actually does today during a search-active render: every
- *              visible CollectionNode independently runs its own
- *              filterCollection over its full subtree. The cascade/single
- *              ratio is the redundancy factor — it's what a single-pass
- *              rewrite would eliminate.
+ * One measurement per (tree shape × size × search variant): the wall time
+ * of a single `computeFilterState(root, searchFilter, searchText)` call
+ * — the work the editor pays once per (data, searchText, searchFilter)
+ * change to decide whole-tree visibility and per-collection visible-child
+ * counts. Replaces the per-node `filterNode` cascade the editor used to
+ * pay on every search-active render.
  *
  * Tree shapes (both via generateTree):
  *   balanced — branching=6 (~log_6 N depth, like real config/document data)
  *   deep     — branching=2 (~log_2 N depth, exposes per-level overhead)
  *
  * Search variants:
- *   empty           — searchText '', no searchFilter → early return inside
- *                     filterNode (sanity baseline)
+ *   empty           — `searchText '', no searchFilter → null-return short
+ *                     circuit (sanity baseline)
  *   no-match value  — matchNode + a string nothing matches → worst case
- *                     (walks every descendant, no .some() short-circuit)
- *   match value     — matchNode + a substring most leaves contain → best
- *                     case (short-circuits at almost every collection)
- *   no-match key    — matchNodeKey + non-matching string → walks every
- *                     descendant; tests path[]-aware matcher cost
+ *                     (visits every node)
+ *   match value     — matchNode + a substring most leaves contain → ~best
+ *                     case under filtering active (still visits every node
+ *                     to count, but each visit is a quick true)
+ *   no-match key    — matchNodeKey + non-matching string → worst case
+ *                     using the path-aware matcher
  *
  * Knobs (env):
  *   FILTER_BENCH_SIZES=1000,10000,50000   leaf counts to test
  *   FILTER_BENCH_SAMPLES=8                samples per measurement
  *   FILTER_BENCH_WARMUP=2                 discarded warmup runs
- *   FILTER_BENCH_INNER=50                 inner-loop iterations per single-call
- *                                         sample (filterNode is fast — averaging
- *                                         many calls per sample beats the
- *                                         performance.now() resolution floor)
+ *   FILTER_BENCH_INNER=20                 inner-loop iterations per sample
+ *                                         (averages the wall-time over many
+ *                                         calls so it clears the
+ *                                         performance.now() resolution
+ *                                         floor on the smaller trees)
  *
- * Run with `pnpm bench` (matches the bench jest config, not the normal test
- * suite). See dev-docs/PERF-BENCH.md for general bench caveats — these are
- * pure-function calls so they're less noisy than the render-cost bench, but
- * the same "use numbers RELATIVELY" rule applies.
+ * Run with `pnpm bench filter` (matches the bench jest config, not the
+ * normal test suite). See dev-docs/PERF-BENCH.md for general caveats —
+ * pure-function calls so less noisy than the render bench, but the same
+ * "use numbers RELATIVELY" rule applies.
  */
 
 import { performance } from 'node:perf_hooks'
-import { filterNode, matchNode, matchNodeKey } from '../../src/utils/filter'
+import { computeFilterState, matchNode, matchNodeKey } from '../../src/utils/filter'
 import { isCollection } from '../../src/utils/misc'
 import { generateTree } from './scenarios'
 import { runSamples, stats, round, printTable } from './harness'
@@ -61,7 +57,7 @@ const SIZES = (process.env.FILTER_BENCH_SIZES ?? '1000,10000,50000')
   .filter((n) => Number.isFinite(n) && n > 0)
 const SAMPLES = num(process.env.FILTER_BENCH_SAMPLES, 8)
 const WARMUP = num(process.env.FILTER_BENCH_WARMUP, 2)
-const INNER = num(process.env.FILTER_BENCH_INNER, 50)
+const INNER = num(process.env.FILTER_BENCH_INNER, 20)
 
 const rootNodeData = (data: JsonData): NodeData => ({
   key: '',
@@ -84,33 +80,6 @@ const countNodes = (data: JsonData): number => {
   return n
 }
 
-// Walk every collection in the tree, calling filterNode at each. Mirrors the
-// per-CollectionNode work the editor does today: each visible collection
-// independently re-runs its own filterCollection over its full subtree.
-const cascadeFilter = (
-  data: JsonData,
-  searchFilter: SearchFilterFunction | undefined,
-  searchText: string
-): void => {
-  const walk = (nd: NodeData) => {
-    if (!isCollection(nd.value)) return
-    filterNode('collection', nd, searchFilter, searchText)
-    for (const [key, value] of Object.entries(nd.value as object)) {
-      walk({
-        key,
-        path: [...nd.path, key],
-        level: nd.level + 1,
-        index: 0,
-        value,
-        size: isCollection(value) ? Object.keys(value as object).length : null,
-        parentData: nd.value as object,
-        fullData: nd.fullData,
-      })
-    }
-  }
-  walk(rootNodeData(data))
-}
-
 interface Variant {
   shape: 'balanced' | 'deep'
   branching: number
@@ -128,7 +97,7 @@ interface Search {
 
 // The synthesised leaf strings cycle through `value ${idx}` for ~1/3 of leaves
 // (see scenarios.ts), so 'value' hits ~every third leaf — a realistic "common
-// substring" case that short-circuits quickly.
+// substring" case.
 const SEARCHES: Search[] = [
   { name: 'empty', filter: undefined, text: '' },
   { name: 'no-match val', filter: matchNode, text: 'zzz_no_match_xyz' },
@@ -143,11 +112,11 @@ describe('filter.ts perf', () => {
       `\nfilter bench config: sizes=[${SIZES.join(', ')}] samples=${SAMPLES} ` +
         `warmup=${WARMUP} inner=${INNER}\n` +
         `forced GC between samples: ${gcActive ? 'ON' : 'OFF (run via `pnpm bench` for --expose-gc)'}\n` +
-        `node + JIT — RELATIVE numbers only; the cascade/single ratio is the redundancy factor.\n`
+        `node + JIT — RELATIVE numbers only.\n`
     )
   })
 
-  test('single + cascade across balanced and deep trees', () => {
+  test('computeFilterState across balanced and deep trees', () => {
     for (const { shape, branching } of VARIANTS) {
       const rows: Record<string, unknown>[] = []
       for (const leafTarget of SIZES) {
@@ -156,37 +125,28 @@ describe('filter.ts perf', () => {
         const root = rootNodeData(data)
 
         for (const s of SEARCHES) {
-          // Single: tight inner loop so the per-sample wall time clears the
-          // performance.now() resolution floor; reported value is mean ms/call.
-          const singleSamples = runSamples(
+          // Tight inner loop so the per-sample wall time clears the
+          // performance.now() resolution floor on smaller trees; reported
+          // value is mean ms/call.
+          const samples = runSamples(
             () => {
               const t0 = performance.now()
               for (let i = 0; i < INNER; i++) {
-                filterNode('collection', root, s.filter, s.text)
+                computeFilterState(root, s.filter, s.text)
               }
               return (performance.now() - t0) / INNER
             },
             { warmup: WARMUP, samples: SAMPLES }
           )
-          const cascadeSamples = runSamples(
-            () => {
-              const t0 = performance.now()
-              cascadeFilter(data, s.filter, s.text)
-              return performance.now() - t0
-            },
-            { warmup: WARMUP, samples: SAMPLES }
-          )
-          const sStats = stats(singleSamples)
-          const cStats = stats(cascadeSamples)
+          const st = stats(samples)
           rows.push({
             leaves,
             nodes,
             search: s.name,
-            'single min (ms)': round(sStats.min, 4),
-            'cascade min (ms)': round(cStats.min, 3),
-            'cascade/single ×': round(cStats.min / Math.max(sStats.min, 1e-6), 1),
-            'single med': round(sStats.median, 4),
-            'cascade med': round(cStats.median, 3),
+            'min (ms)': round(st.min, 4),
+            'med (ms)': round(st.median, 4),
+            'p95 (ms)': round(st.p95, 4),
+            'ns/node': round((st.min * 1_000_000) / nodes, 0),
           })
         }
       }

--- a/test/perf/filter.bench.ts
+++ b/test/perf/filter.bench.ts
@@ -1,0 +1,197 @@
+/**
+ * filterNode / filterCollection performance bench.
+ *
+ * Two measurements per tree × search variant:
+ *
+ *   single   — one filterNode('collection', root, ...) call. This is the
+ *              cost of computing whole-tree visibility once, i.e. what a
+ *              hypothetical top-level precompute would pay.
+ *   cascade  — call filterNode('collection', ...) at EVERY collection node
+ *              in the tree, depth-first. This mirrors the work the editor
+ *              actually does today during a search-active render: every
+ *              visible CollectionNode independently runs its own
+ *              filterCollection over its full subtree. The cascade/single
+ *              ratio is the redundancy factor — it's what a single-pass
+ *              rewrite would eliminate.
+ *
+ * Tree shapes (both via generateTree):
+ *   balanced — branching=6 (~log_6 N depth, like real config/document data)
+ *   deep     — branching=2 (~log_2 N depth, exposes per-level overhead)
+ *
+ * Search variants:
+ *   empty           — searchText '', no searchFilter → early return inside
+ *                     filterNode (sanity baseline)
+ *   no-match value  — matchNode + a string nothing matches → worst case
+ *                     (walks every descendant, no .some() short-circuit)
+ *   match value     — matchNode + a substring most leaves contain → best
+ *                     case (short-circuits at almost every collection)
+ *   no-match key    — matchNodeKey + non-matching string → walks every
+ *                     descendant; tests path[]-aware matcher cost
+ *
+ * Knobs (env):
+ *   FILTER_BENCH_SIZES=1000,10000,50000   leaf counts to test
+ *   FILTER_BENCH_SAMPLES=8                samples per measurement
+ *   FILTER_BENCH_WARMUP=2                 discarded warmup runs
+ *   FILTER_BENCH_INNER=50                 inner-loop iterations per single-call
+ *                                         sample (filterNode is fast — averaging
+ *                                         many calls per sample beats the
+ *                                         performance.now() resolution floor)
+ *
+ * Run with `pnpm bench` (matches the bench jest config, not the normal test
+ * suite). See dev-docs/PERF-BENCH.md for general bench caveats — these are
+ * pure-function calls so they're less noisy than the render-cost bench, but
+ * the same "use numbers RELATIVELY" rule applies.
+ */
+
+import { performance } from 'node:perf_hooks'
+import { filterNode, matchNode, matchNodeKey } from '../../src/utils/filter'
+import { isCollection } from '../../src/utils/misc'
+import { generateTree } from './scenarios'
+import { runSamples, stats, round, printTable } from './harness'
+import type { JsonData, NodeData, SearchFilterFunction } from '../../src/types'
+
+const num = (env: string | undefined, fallback: number) => {
+  const n = parseInt(env ?? '', 10)
+  return Number.isFinite(n) ? n : fallback
+}
+
+const SIZES = (process.env.FILTER_BENCH_SIZES ?? '1000,10000,50000')
+  .split(',')
+  .map((s) => parseInt(s.trim(), 10))
+  .filter((n) => Number.isFinite(n) && n > 0)
+const SAMPLES = num(process.env.FILTER_BENCH_SAMPLES, 8)
+const WARMUP = num(process.env.FILTER_BENCH_WARMUP, 2)
+const INNER = num(process.env.FILTER_BENCH_INNER, 50)
+
+const rootNodeData = (data: JsonData): NodeData => ({
+  key: '',
+  path: [],
+  level: 0,
+  index: 0,
+  value: data,
+  size: isCollection(data) ? Object.keys(data as object).length : null,
+  parentData: null,
+  fullData: data,
+})
+
+const countNodes = (data: JsonData): number => {
+  let n = 0
+  const walk = (v: JsonData) => {
+    n += 1
+    if (isCollection(v)) for (const child of Object.values(v as object)) walk(child)
+  }
+  walk(data)
+  return n
+}
+
+// Walk every collection in the tree, calling filterNode at each. Mirrors the
+// per-CollectionNode work the editor does today: each visible collection
+// independently re-runs its own filterCollection over its full subtree.
+const cascadeFilter = (
+  data: JsonData,
+  searchFilter: SearchFilterFunction | undefined,
+  searchText: string
+): void => {
+  const walk = (nd: NodeData) => {
+    if (!isCollection(nd.value)) return
+    filterNode('collection', nd, searchFilter, searchText)
+    for (const [key, value] of Object.entries(nd.value as object)) {
+      walk({
+        key,
+        path: [...nd.path, key],
+        level: nd.level + 1,
+        index: 0,
+        value,
+        size: isCollection(value) ? Object.keys(value as object).length : null,
+        parentData: nd.value as object,
+        fullData: nd.fullData,
+      })
+    }
+  }
+  walk(rootNodeData(data))
+}
+
+interface Variant {
+  shape: 'balanced' | 'deep'
+  branching: number
+}
+const VARIANTS: Variant[] = [
+  { shape: 'balanced', branching: 6 },
+  { shape: 'deep', branching: 2 },
+]
+
+interface Search {
+  name: string
+  filter: SearchFilterFunction | undefined
+  text: string
+}
+
+// The synthesised leaf strings cycle through `value ${idx}` for ~1/3 of leaves
+// (see scenarios.ts), so 'value' hits ~every third leaf — a realistic "common
+// substring" case that short-circuits quickly.
+const SEARCHES: Search[] = [
+  { name: 'empty', filter: undefined, text: '' },
+  { name: 'no-match val', filter: matchNode, text: 'zzz_no_match_xyz' },
+  { name: 'match val', filter: matchNode, text: 'value' },
+  { name: 'no-match key', filter: matchNodeKey, text: 'zzz_no_match_key' },
+]
+
+describe('filter.ts perf', () => {
+  beforeAll(() => {
+    const gcActive = typeof (globalThis as { gc?: () => void }).gc === 'function'
+    console.log(
+      `\nfilter bench config: sizes=[${SIZES.join(', ')}] samples=${SAMPLES} ` +
+        `warmup=${WARMUP} inner=${INNER}\n` +
+        `forced GC between samples: ${gcActive ? 'ON' : 'OFF (run via `pnpm bench` for --expose-gc)'}\n` +
+        `node + JIT — RELATIVE numbers only; the cascade/single ratio is the redundancy factor.\n`
+    )
+  })
+
+  test('single + cascade across balanced and deep trees', () => {
+    for (const { shape, branching } of VARIANTS) {
+      const rows: Record<string, unknown>[] = []
+      for (const leafTarget of SIZES) {
+        const { data, leaves } = generateTree(leafTarget, branching)
+        const nodes = countNodes(data)
+        const root = rootNodeData(data)
+
+        for (const s of SEARCHES) {
+          // Single: tight inner loop so the per-sample wall time clears the
+          // performance.now() resolution floor; reported value is mean ms/call.
+          const singleSamples = runSamples(
+            () => {
+              const t0 = performance.now()
+              for (let i = 0; i < INNER; i++) {
+                filterNode('collection', root, s.filter, s.text)
+              }
+              return (performance.now() - t0) / INNER
+            },
+            { warmup: WARMUP, samples: SAMPLES }
+          )
+          const cascadeSamples = runSamples(
+            () => {
+              const t0 = performance.now()
+              cascadeFilter(data, s.filter, s.text)
+              return performance.now() - t0
+            },
+            { warmup: WARMUP, samples: SAMPLES }
+          )
+          const sStats = stats(singleSamples)
+          const cStats = stats(cascadeSamples)
+          rows.push({
+            leaves,
+            nodes,
+            search: s.name,
+            'single min (ms)': round(sStats.min, 4),
+            'cascade min (ms)': round(cStats.min, 3),
+            'cascade/single ×': round(cStats.min / Math.max(sStats.min, 1e-6), 1),
+            'single med': round(sStats.median, 4),
+            'cascade med': round(cStats.median, 3),
+          })
+        }
+      }
+      printTable(`FILTER — ${shape} tree (branching=${branching})`, rows)
+    }
+    expect(true).toBe(true)
+  })
+})

--- a/v2-filtered-collection-count.md
+++ b/v2-filtered-collection-count.md
@@ -1,0 +1,123 @@
+# Filtered collection count + filter rewrite — V2 plan
+
+Tracking discussion + implementation plan for [#113](https://github.com/CarlosNZ/json-edit-react/issues/113) and the related filter inefficiency surfaced in [search_analysis.md](search_analysis.md). The two issues share the same data and should land as one architectural change.
+
+## The user-visible feature
+
+When `searchText` / `searchFilter` is active and `showCollectionCount` is on, collection counts still reflect the full underlying data, not what's visible. Display `n of m` (e.g. `3 of 47 items`) when search is active and the visible count differs from the total. Preserves the "data hasn't actually been removed" semantics while answering the question users actually have under search ("how many matched?"). This is what GitHub, Finder, most data grids do.
+
+A demo-page payoff for V2: most other V2 work is under-the-hood; this one is immediately visible on the home page if we drop a search box on the headline example.
+
+## The related rewrite ([search_analysis.md](search_analysis.md))
+
+`filterCollection` (src/utils/filter.ts) is currently called per-visible-CollectionNode, each call doing a full subtree walk. Cost ≈ Σ (subtree sizes) ≈ O(n × depth). The fix is a single post-order DFS at the `JsonEditor` level that computes visibility once per `(data, debouncedSearchText, resolvedSearchFilter)`, producing a `Set<pathString>` of visible nodes. Nodes look their answer up instead of recomputing.
+
+The n-of-m count falls out of that same walk **for free**. Same data is needed: "given a collection, which of its direct children are visible?". One pass can produce both outputs:
+
+- `visiblePaths: Set<string>` — drives the visibility lookup at every call site
+- `visibleChildCounts: Map<string, number>` — drives the count display
+
+## Bench numbers (today's baseline)
+
+`pnpm bench filter` ([test/perf/filter.bench.ts](test/perf/filter.bench.ts)) measures both a single root-level filterNode call and a cascade walk that calls filterNode at every collection node in the tree (what the editor actually does on a search-active render). The cascade/single ratio is the redundancy multiplier — the work a single-pass rewrite would eliminate.
+
+Smoke run, 2000 leaves, no-match value search:
+
+| shape | single ms | cascade ms | ratio |
+|---|---|---|---|
+| balanced (branching=6) | 1.78 | 7.72 | **4.3×** |
+| deep (branching=2) | 2.33 | 25.19 | **10.8×** |
+
+Ratio grows with depth, as expected. At ~50k nodes on deep trees the no-match cascade is into the hundreds of ms — that's the regime where users would actually feel it. Today's "feels instant" intuition is largely because the demo's massive set renders mostly collapsed; search-on-fully-expanded large data is where the inefficiency would bite.
+
+## The known correctness bug (narrower than first thought)
+
+`filterCollection` recurses into a child collection without first testing the child's own matcher. So an intermediate collection whose key would match drops out if it has no matching-leaf descendants — and drags its ancestors with it.
+
+Three `test.failing` regression cases at [test/filter-bug.test.tsx](test/filter-bug.test.tsx). Strip `.failing` once the fix lands.
+
+The bug is narrower than the original analysis implied. `matchNodeKey` checks the **full path**, so deep leaves under a key-matching collection inherit the match via their path — that papers over the bug in most realistic scenarios. The bug only surfaces when:
+
+1. The matching key has no descendants whose path the matcher would accept (mainly empty `{}` / `[]` bodies), or
+2. A custom `searchFilter` is used that doesn't consult `path` (e.g. matches only on `key` or `value`).
+
+The built-in `'value'` filter can't hit this case — `matchNode` always returns false for collection values, so the "key matches but no descendant matches" situation can't arise. Frame it as a custom-filter + empty-collection bug, not a widespread regression.
+
+## Implementation sketch
+
+### 1. Single walk at `JsonEditor` level
+
+```ts
+const visiblePaths = useMemo(() => {
+  if (!searchFilter && !debouncedSearchText) return null // null = no filtering
+  const visible = new Set<string>()
+  const childCounts = new Map<string, number>()
+  const walk = (nodeData: NodeData): boolean => {
+    let matched = matcher(nodeData, debouncedSearchText)
+    let visibleChildren = 0
+    if (isCollection(nodeData.value)) {
+      for (const childNodeData of childrenOf(nodeData)) {
+        if (walk(childNodeData)) { matched = true; visibleChildren++ }
+      }
+      childCounts.set(toPathString(nodeData.path), visibleChildren)
+    }
+    if (matched) visible.add(toPathString(nodeData.path))
+    return matched
+  }
+  walk(rootNodeData)
+  return { visible, childCounts }
+}, [data, debouncedSearchText, searchFilter])
+```
+
+No short-circuit: siblings still need visiting to populate counts. That's the right cost — a single linear pass that does what today's redundant cascade was doing log/linearly-many times.
+
+### 2. Replace `filterNode` call sites
+
+Two of them today: `CollectionNode.tsx:215` and `ValueNodeWrapper.tsx:187`. Both become `visiblePaths === null || visiblePaths.has(toPathString(path))`. The current `filterNode` / `filterCollection` exports stay (they're public-ish via the test surface and could be used externally), but the editor stops calling them on the hot path.
+
+### 3. Wire counts
+
+Pass the `childCounts` map via context (probably the same context that exposes `visiblePaths`). `CollectionNode` reads its count from `map.get(toPathString(path))` and renders `n of m` when n ≠ m. Add an `ITEMS_FILTERED` translation with `{visible}` + `{total}` placeholders.
+
+### 4. API
+
+Either extend `showCollectionCount` with a `'filtered'` literal, or add a separate `collectionCountFilter: 'total' | 'filtered' | 'both'` defaulting to `'both'` when search is active. Lean toward the second — keeps the existing prop focused on *whether* to show vs. *what* to show.
+
+### 5. Stable references
+
+`visiblePaths` and `childCounts` are recomputed only when `(data, debouncedSearchText, searchFilter)` change — between those changes the references are stable, so the §16 memo invariants ([dev-docs/PERF-ARCHITECTURE.md](dev-docs/PERF-ARCHITECTURE.md)) hold. Worth verifying that no node's memo comparator depends on searchText *prop* identity rather than the context value — if so, threading per-node `isVisible: boolean` via context selector is the cleaner downstream optimisation (visibility-flip-only re-renders).
+
+## Cheap intermediate fix
+
+Independent of the big rewrite, **export `filterNode` from [src/utils/filter.ts](src/utils/filter.ts)** so users can produce a filtered count today via a `customText.ITEMS_MULTIPLE` callback. ~0 B bundle cost (it's already in the bundle, just not re-exported). Issue #113 becomes "use this workaround" for users who need it before V2 ships.
+
+Userland shape with `filterNode` exported:
+
+```tsx
+const customText = useMemo(() => ({
+  ITEMS_MULTIPLE: (nodeData) => {
+    if (!searchText) return null
+    const visible = Object.entries(nodeData.value).filter(([k, v]) => {
+      const childNodeData = {
+        ...nodeData, key: k, value: v,
+        path: [...nodeData.path, k],
+        level: nodeData.level + 1,
+        parentData: nodeData.value,
+      }
+      return filterNode(isCollection(v) ? 'collection' : 'value', childNodeData, mySearchFilter, searchText)
+    }).length
+    return `${visible} of ${nodeData.size} items`
+  },
+}), [searchText, mySearchFilter])
+```
+
+## Order of work
+
+1. Export `filterNode` — tiny standalone change, viable answer for #113 immediately.
+2. Bug-repro regression tests are in already — see [test/filter-bug.test.tsx](test/filter-bug.test.tsx). Run `pnpm test filter-bug` to verify they currently fail-as-expected.
+3. Single-pass walk + bug-fix verification + n-of-m display + new prop — one PR, since they share the architecture.
+4. Optional follow-up: visibility-flip-only re-render (thread per-node `isVisible` via context selector).
+
+## Bundle impact
+
+V2 is currently ~629 B over V1 ([project_v2_bundle_smaller_than_v1](.claude/projects/-Users-carl-GitHub-json-edit-react/memory/project_v2_bundle_smaller_than_v1.md)). The rewrite replaces the existing recursive filter with a single walk — likely net-neutral or a slight win (replaces two recursive functions with one). The count feature adds ~100–150 B (helper output + display branch + i18n key + prop). Total likely a small net add; worth measuring with `pnpm preview-publish` once the work is done.


### PR DESCRIPTION
## Summary

Closes #113 (well, the implementation half — final decision is yours).

- **Feature**: Collection counts now reflect the active search filter as `n of m` (e.g. `"3 of 20 items"`). Driven by a new `'when-closed-or-filtered'` literal on `showCollectionCount`, which is the new default — counts surface automatically when search narrows the visible children, even on open nodes.
- **Internal rewrite**: Per-node `filterNode` cascade replaced with a single post-order walk (`computeFilterState`) at the editor level, surfaced via a new `FilterStateProvider` context slice. `searchText` / `searchFilter` are no longer per-node props.
- **Two latent bug fixes** fall out of the rewrite (see changeset for details).

### Perf (filter bench, 2000 leaves, no-match search)

| shape | before (cascade) | after (single walk) | speedup |
|---|---|---|---|
| balanced b=6, no-match val | 7.72 ms | 1.10 ms | ~7× |
| balanced b=6, no-match key | 8.32 ms | 1.21 ms | ~7× |
| deep b=2, no-match val | 25.19 ms | 3.17 ms | ~8× |
| deep b=2, no-match key | 29.13 ms | 3.74 ms | ~8× |

Ratio grows with depth — the cascade cost was `O(n × depth)`; the walk is `O(n)`. Numbers via `pnpm bench filter`.

### API surface

| Setting | Behaviour |
|---|---|
| `showCollectionCount={true}` | Always show |
| `showCollectionCount={false}` | Never show |
| `showCollectionCount="when-closed"` | Only when closed (V1 behaviour) |
| `showCollectionCount="when-closed-or-filtered"` | When closed OR search is filtering (new default) |
| Override `customText.ITEMS_FILTERED` | Custom format, or suppress the n-of-m form entirely |

`showFilteredCollectionCounts` was considered but dropped in favour of folding both axes into the single existing prop — see the discussion in v2-filtered-collection-count.md (in the parent commit on this branch).

## Test plan

- [x] `pnpm test` — 445 tests across 18 suites passing, including 4 new n-of-m cases (`JsonEditor.test.tsx`), 3 bug-regression guards (`filter-bug.test.tsx`, previously `.failing`), and 8 new `computeFilterState` unit cases (`filter.test.ts`)
- [x] `pnpm lint` — clean
- [x] `pnpm compile` — clean (project-wide tsc + ts-prune)
- [x] `pnpm build` — clean
- [x] `pnpm bench filter` — numbers above; see `test/perf/filter.bench.ts`
- [ ] Manual demo eyeball: `pnpm dev`, search on any example, verify n-of-m surfaces on open nodes by default and disappears when search is cleared
- [ ] Manual bug repro: paste `{ rootContainer: { interestingThing: {} } }`, set `searchFilter="key"` + `searchText="interestingThing"` — `interestingThing` should now be visible (was hidden before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)