### PR TITLE
Align closing bracket with the key/opening line (#220)

### DIFF
--- a/.changeset/closing-bracket-key-alignment.md
+++ b/.changeset/closing-bracket-key-alignment.md
@@ -1,0 +1,7 @@
+---
+'json-edit-react': patch
+---
+
+The closing bracket of an expanded object/array now aligns horizontally with the key (the start of the opening line), matching how JSON pretty-printers position a close bracket under the line that opened it. Previously it carried a depth-dependent offset that drifted toward the collapse chevron at the default indent. The alignment is now independent of the `indent` prop (#220).
+
+Breaking only for custom CSS that positioned the outside closing bracket via `.jer-bracket-outside`: it no longer sets `padding-left`, so any rule that compensated for the old offset should be removed.

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -708,6 +708,10 @@ The only thing to act on is **custom CSS that targets these controls by tag name
 
 Selectors that target the wrapper classes (`.jer-confirm-buttons`, `.jer-edit-buttons`) or the icons themselves are unaffected. Consumer-supplied custom buttons (`customButtons`) remain wrapped in a `<div>`, so their markup is unchanged.
 
+### Closing-bracket alignment
+
+The closing bracket of an expanded object/array now aligns with the key (the start of the opening line) at every depth, rather than carrying a depth-dependent offset toward the collapse chevron. The only thing to act on is **custom CSS that positioned the outside closing bracket** via `.jer-bracket-outside`: that class no longer sets `padding-left`, so if you added a rule to compensate for the old offset, remove it.
+
 ---
 
 ## Need help?

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -657,10 +657,7 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
         {!isEditing && showCollectionWrapper && (
           <div
             className="jer-brackets jer-bracket-outside"
-            style={{
-              ...getStyles('bracket', nodeData),
-              marginLeft: `${indent < 3 ? -1 : indent < 6 ? -0.5 : 0}em`,
-            }}
+            style={getStyles('bracket', nodeData)}
           >
             {brackets.close}
           </div>

--- a/src/style.css
+++ b/src/style.css
@@ -146,8 +146,13 @@ select:focus + .focus {
 /* .jer-brackets {
 } */
 
+/* The closing bracket sits at the same column as the opening line (the key),
+   matching how JSON pretty-printers align a close bracket under the start of
+   the line that opened it. Its container shares the header row's left edge, so
+   no offset is needed — and the alignment is deliberately independent of
+   `indent`. */
 .jer-bracket-outside {
-  padding-left: 0.5em;
+  padding-left: 0;
 }
 
 /* Hidden by `display: none` (not `opacity: 0` alone) so a hidden count


### PR DESCRIPTION
Closes #220.

## What

The closing bracket of an expanded object/array now aligns horizontally with the **key** (the start of the opening line), matching how JSON pretty-printers position a close bracket under the line that opened it.

Previously the outside closing bracket carried a depth-dependent inline offset:

```js
marginLeft: `${indent < 3 ? -1 : indent < 6 ? -0.5 : 0}em`
```

combined with a `padding-left: 0.5em` on `.jer-bracket-outside`. At the default `indent` of 2 this netted to −0.5em, pulling the bracket leftward toward the collapse chevron — the misalignment reported in #220 — and it drifted further as depth changed.

**Before**:

<img width="347" height="329" alt="Screenshot 2026-06-16 at 11 52 28 AM" src="https://github.com/user-attachments/assets/424dea39-2790-4e37-8f73-8b926d7de3f7" />

**After**:

<img width="362" height="334" alt="Screenshot 2026-06-16 at 11 52 16 AM" src="https://github.com/user-attachments/assets/ed228f08-1d01-4aae-84fb-22d789adc86d" />

## How

The closing bracket's container (`.jer-collection-inner`) already shares the header row's left edge, and the key sits at that edge (the chevron is `position: absolute` in the gutter, out of flow). So "align with the key" is simply "offset 0" — no expression needed:

- Dropped the indent-dependent inline `marginLeft` in `CollectionNode.tsx`.
- Set `.jer-bracket-outside` `padding-left: 0.5em` → `0`.

The alignment is now **independent of `indent`** at every depth.

## Verification

Measured in the running demo (`VITE_JRE_SOURCE=local`): the closing bracket's left edge equals the key's left edge to the pixel across nesting levels (e.g. 47/47, 63/63, 79/79), with the chevron ~19px left in the gutter and the open bracket out to the right after the key text.

This is a static-layout change with no JS behaviour change, so the jsdom/RTL suite has nothing meaningful to assert; `pnpm compile` is clean.

## Docs

- Changeset: `json-edit-react: patch`.
- Migration guide: new *Closing-bracket alignment* subsection under §14, flagging that `.jer-bracket-outside` no longer sets `padding-left` for anyone who styled against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)