### PR TITLE
Fix edit lock after data swap + caret jump on rejected input

### DIFF
--- a/.changeset/editing-unmount-and-caret-fixes.md
+++ b/.changeset/editing-unmount-and-caret-fixes.md
@@ -1,0 +1,9 @@
+---
+'json-edit-react': patch
+---
+
+Fix two editing bugs.
+
+Replacing the whole `data` (e.g. switching data set) while a node was being edited left the editor unable to start any new edit. The displaced node's `cancelEdit` was rebuilt from the live document, but its path no longer existed there, so the rebuild threw and stranded the editing session. The editing event now tolerates a vanished path, and a node that owns the active edit session now closes it when it unmounts.
+
+Typing a character that the consumer's `onChange` rejects or rewrites (e.g. stripping a disallowed character) while the caret was mid-string jumped the caret to the end after the first keystroke. The caret now stays where you were typing.

--- a/src/AutogrowTextArea.tsx
+++ b/src/AutogrowTextArea.tsx
@@ -8,7 +8,7 @@
  * the basic idea of how it works.
  */
 
-import React from 'react'
+import React, { useCallback, useRef } from 'react'
 
 interface TextAreaProps {
   className: string
@@ -29,6 +29,38 @@ export const AutogrowTextArea: React.FC<TextAreaProps> = ({
   styles,
   textAreaRef,
 }) => {
+  // Own ref to the textarea (also forwarded to the optional `textAreaRef`), so
+  // the caret-restore below can reach the element regardless of the caller.
+  const innerRef = useRef<HTMLTextAreaElement | null>(null)
+  const setRef = useCallback(
+    (el: HTMLTextAreaElement | null) => {
+      innerRef.current = el
+      if (textAreaRef) textAreaRef.current = el
+    },
+    [textAreaRef]
+  )
+
+  // Restore the caret after a keystroke that the consumer's `onChange` rejects
+  // or rewrites. This is a CONTROLLED textarea, so when the settled `value`
+  // differs from what was typed (e.g. a disallowed character was stripped),
+  // React resets the DOM value to match the prop — and the browser drops the
+  // caret to the END. A microtask runs after React's synchronous
+  // controlled-state restore (which is what moves the caret) but before paint,
+  // so the corrected caret never flashes. Reading the SETTLED `el.value` rather
+  // than the captured keystroke covers a full rejection too (where the value
+  // is unchanged, so no re-render fires — an effect wouldn't run at all).
+  const restoreCaret = (el: HTMLTextAreaElement, caret: number, typed: string) => {
+    queueMicrotask(() => {
+      if (innerRef.current !== el) return // editor closed / element replaced
+      const settled = el.value
+      if (settled === typed) return // accepted as typed → browser caret is fine
+      // Shift the caret back by however many characters were dropped (negative
+      // if the transform inserted), keeping it where the user was typing.
+      const next = Math.max(0, Math.min(caret - (typed.length - settled.length), settled.length))
+      el.setSelectionRange(next, next)
+    })
+  }
+
   // Adding extra (hidden) char when adding new lines to input prevents
   // mis-alignment between real value and dummy value
   if (typeof value !== 'string') return null
@@ -38,7 +70,7 @@ export const AutogrowTextArea: React.FC<TextAreaProps> = ({
     <div style={{ display: 'grid' }}>
       <textarea
         id={`${name}_textarea`}
-        ref={textAreaRef}
+        ref={setRef}
         style={{
           height: 'auto',
           gridArea: '1 / 1 / 2 / 2',
@@ -51,7 +83,10 @@ export const AutogrowTextArea: React.FC<TextAreaProps> = ({
         className={className}
         name={`${name}_textarea`}
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => {
+          restoreCaret(e.target, e.target.selectionStart ?? 0, e.target.value)
+          setValue(e.target.value)
+        }}
         autoFocus
         onFocus={(e) => {
           if (value.length < 40) e.target.select()

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -30,7 +30,7 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
   const { getStyles } = useTheme()
   // Actions + imperative reads from the (stable) store — no subscription, so
   // editing transitions elsewhere don't re-render this node.
-  const { open, cancel, submit, areChildrenBeingEdited } = useEditingStore()
+  const { open, cancel, submit, areChildrenBeingEdited, closeIfActive } = useEditingStore()
   const { setCollapseState } = useCollapse()
   const {
     mainContainerRef,
@@ -133,6 +133,16 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
   // Contract #1: apply broadcast commands targeting this node. See
   // CollapseProvider top-of-file doc.
   useAppliedBroadcast(path, hasBeenOpened, animateCollapse)
+
+  // If THIS node owns the active session (whole-node JSON edit, key rename, or
+  // add) when it unmounts — e.g. the whole `data` was swapped out from under
+  // it — drop the session so the store doesn't strand a phantom `active` on a
+  // vanished node, which would block every subsequent edit. Reads the latest
+  // path from a ref so a reused fiber whose path changed still clears the
+  // right session.
+  const pathRef = useRef(path)
+  pathRef.current = path
+  useEffect(() => () => closeIfActive(pathRef.current), [closeIfActive])
 
   // For JSON-editing TextArea
   const textAreaRef = useRef<HTMLTextAreaElement>(null)

--- a/src/ValueNodeWrapper.tsx
+++ b/src/ValueNodeWrapper.tsx
@@ -64,7 +64,7 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
   // this node reads (via `getSnapshot`) is only consulted inside event
   // handlers, never during render. The only editing state that drives this
   // node's render (`isEditing`) comes from `useCommon`'s per-node selector.
-  const { open, cancel, submit, getSnapshot } = useEditingStore()
+  const { open, cancel, submit, getSnapshot, closeIfActive } = useEditingStore()
   const { setCollapseState } = useCollapse()
   const [value, setValue] = useState<typeof data | CollectionData>(
     // Bad things happen when you put a function into useState
@@ -151,6 +151,16 @@ const ValueNodeWrapperBase: React.FC<ValueNodeProps> = (props) => {
     if (!derivedValues.isEditing) revertToData()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data])
+
+  // If THIS node owns the active editing session when it unmounts (e.g. the
+  // whole `data` was swapped out from under an open edit), drop the session.
+  // Otherwise the store strands a phantom `active` on a vanished node, which
+  // blocks every subsequent edit. Reads the latest path from `nodeDataRef` so
+  // a reused fiber whose path changed still clears the right session.
+  useEffect(
+    () => () => closeIfActive(nodeDataRef.current.path),
+    [closeIfActive]
+  )
 
   const allowedDataTypes = useMemo(() => {
     // Include custom node options in dataType list

--- a/src/contexts/EditingProvider.tsx
+++ b/src/contexts/EditingProvider.tsx
@@ -186,6 +186,10 @@ export interface EditingStore {
   submit: (args: SubmitArgs) => Promise<UpdateOutcome | undefined>
   /** Imperative read for event handlers — does not subscribe. */
   areChildrenBeingEdited: (path: CollectionKey[]) => boolean
+  /** Drop the active session if it targets `path` (and isn't held). Called when
+   *  the editing node unmounts so the store never strands a phantom session on
+   *  a node that no longer exists (e.g. the whole `data` was swapped out). */
+  closeIfActive: (path: CollectionKey[]) => void
 }
 
 const initialState: EditingStateBundle = {
@@ -246,7 +250,18 @@ const createEditingStore = (
     extra?: Record<string, unknown>
   ) => {
     if (!onEditEventRef.current) return
-    const nodeData = buildNodeDataFromPathRef.current?.(path)
+    // The path may no longer resolve in the live document — e.g. a displaced
+    // `cancel*` whose node vanished because the whole `data` was swapped out
+    // from under an open session. `buildNodeData` THROWS on a missing path, so
+    // guard it: a vanished node has no `NodeData` to report, so skip the event
+    // rather than let the throw escape `open`/`cancel` (which would abort the
+    // caller and strand the editing session, blocking all further edits).
+    let nodeData: NodeData | undefined
+    try {
+      nodeData = buildNodeDataFromPathRef.current?.(path)
+    } catch {
+      return
+    }
     if (nodeData) emitEvent(nodeData, event, extra)
   }
 
@@ -308,6 +323,22 @@ const createEditingStore = (
     } finally {
       cancelling = false
     }
+  }
+
+  // ── closeIfActive: drop a session whose node has unmounted ────────────────
+  const closeIfActive = (path: CollectionKey[]) => {
+    const active = state.active
+    // A held op resolves only through its gate, so leave it be. Otherwise only
+    // act when THIS node owns the active session (a node unmounting while a
+    // DIFFERENT node edits — Tab away, sibling delete — must not touch it).
+    if (active === null || active.phase === 'held' || !pathsEqual(active.path, path)) return
+    // Run this session's buffer cleanup (idempotent no-op on the now-unmounted
+    // node) and clear `active` silently — the node is gone, so there's no
+    // `NodeData` to report and no `cancel*` to fire.
+    const op0 = cancelOp
+    cancelOp = null
+    if (op0) op0()
+    commit({ ...state, active: null })
   }
 
   const addSettling = (pathStr: PathString, token: Token) =>
@@ -490,6 +521,7 @@ const createEditingStore = (
     submit,
     areChildrenBeingEdited: (path) =>
       state.active !== null && isDescendantOf(state.active.path, path),
+    closeIfActive,
   }
 }
 
@@ -572,6 +604,7 @@ export const useEditing = () => {
       cancel: store.cancel,
       submit: store.submit,
       areChildrenBeingEdited: store.areChildrenBeingEdited,
+      closeIfActive: store.closeIfActive,
     }),
     [bundle, store]
   )

--- a/test/JsonEditor.test.tsx
+++ b/test/JsonEditor.test.tsx
@@ -488,6 +488,35 @@ describe('JsonEditor — edit flow', () => {
     expect(screen.getByText('"hello"')).toBeInTheDocument()
   })
 
+  test('an `onChange` that rejects a character keeps the caret in place (no jump to end)', async () => {
+    // Regression: the edit textarea is controlled, so when `onChange` rewrites
+    // a keystroke (here: stripping a disallowed "."), React reassigns the DOM
+    // value and the browser resets the caret to the END. Typing a rejected
+    // character mid-string then jumped the caret away. The caret must instead
+    // stay where the user was typing.
+    const user = userEvent.setup()
+    // Strip any "." — mirrors a data model that disallows dots in the value.
+    const onChange = ({ newValue }: { newValue: unknown }) => String(newValue).replace(/\./g, '')
+    render(<JsonEditor data={{ name: 'abc' }} setData={noop} onChange={onChange} />)
+
+    await user.dblClick(screen.getByText('"abc"'))
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement
+    expect(input.value).toBe('abc')
+
+    // Caret between 'a' and 'b', then type a rejected ".".
+    await user.type(input, '.', {
+      skipClick: true,
+      initialSelectionStart: 1,
+      initialSelectionEnd: 1,
+    })
+
+    // The "." was rejected, so the value is unchanged AND the caret stayed put
+    // (position 1) rather than jumping to the end (position 3).
+    expect(input.value).toBe('abc')
+    expect(input.selectionStart).toBe(1)
+    expect(input.selectionEnd).toBe(1)
+  })
+
   // Documents current behaviour: there is no document-level outside-click
   // handler. Clicking neutral chrome (e.g. the root key label) while editing
   // is a no-op — the input stays open. Cancelling on outside click would
@@ -540,6 +569,39 @@ describe('JsonEditor — edit flow', () => {
     expect(inputs).toHaveLength(1)
     expect((inputs[0] as HTMLTextAreaElement).value).toBe('two')
     expect(setData).not.toHaveBeenCalled()
+  })
+
+  test('swapping `data` while editing (the editing node unmounts) does not lock further edits', async () => {
+    // Regression: the displaced-`cancel*` path rebuilt the outgoing node's
+    // `NodeData` from the LIVE document. After the whole `data` was swapped,
+    // the old path no longer resolved, so `buildNodeData` threw — aborting
+    // `open` before it set the new session and stranding `active` on the
+    // vanished node. Every later `open` re-threw, so NO further edits worked.
+    // `onEditEvent` is required to reproduce: it's what drives the rebuild.
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn()
+    const Harness = () => {
+      const [data, setData] = useState<JsonData>({ alpha: 'one', beta: 'two' })
+      return (
+        <>
+          <button onClick={() => setData([{ name: 'fresh' }])}>swap</button>
+          <JsonEditor data={data} setData={setData} onEditEvent={onEditEvent} />
+        </>
+      )
+    }
+    render(<Harness />)
+
+    await user.dblClick(screen.getByText('"one"'))
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('one')
+
+    // Swap to a differently-shaped dataset (object → array): the 'alpha' node
+    // unmounts while it is the active edit, and its path stops resolving.
+    await user.click(screen.getByText('swap'))
+    expect(screen.queryByRole('textbox')).toBeNull()
+
+    // Editing a node in the NEW dataset must still open.
+    await user.dblClick(screen.getByText('"fresh"'))
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('fresh')
   })
 
   test('clicking the OK icon confirms the edit (same as pressing Enter)', async () => {


### PR DESCRIPTION
Fixes two editing bugs.

## 1. Editing dies after switching data set

Replacing the whole `data` (e.g. switching dataset in the demo) while a node was being edited left the editor unable to start **any** new edit.

**Root cause:** when you `open` a new edit, the store fires a `cancelEdit` for the *displaced* node, rebuilding that node's `NodeData` from the **live** document. After a dataset swap the old path no longer exists, so `buildNodeData` → `extract` **throws** — escaping `open` before `setActive` ran, leaving `active` pinned to the vanished node. Every subsequent `open` re-threw the same way, so editing was globally dead. (Only reproduces when an `onEditEvent` is present, which is why the demo broke but a bare `<JsonEditor>` didn't.)

**Fix:**
- `fireEditEvent` now tolerates a vanished path — it already guarded `if (nodeData)`, expecting a missing node, so the throw was violating that contract.
- New `closeIfActive` store action, called from an unmount effect in `ValueNodeWrapper` / `CollectionNode`, so a node that owns the active session closes it when it unmounts and the store never strands a phantom session.

## 2. Caret jumps to the end on rejected input

Typing a character the consumer's `onChange` rejects/rewrites (e.g. stripping a disallowed `.`) while the caret was mid-string jumped the caret to the end after the first keystroke.

The edit textarea is controlled, so when the settled value differs from what was typed, React resets the DOM value and the browser drops the caret to the end. On a *full* rejection the value is unchanged (no re-render fires), and React's controlled-state restore runs *after* the event handler — so an effect can't fix it. `AutogrowTextArea` now restores the caret in a **microtask** (after the restore, before paint), shifted back by however many characters were dropped.

## Testing

- Two regression tests added; each confirmed to **fail** without its fix.
- Full suite (500 tests), lint, and typecheck pass.
- Both fixes verified manually in the running demo (dataset switch from an open edit; the "Mrs. Dennis Schulist" caret on the Client List).

🤖 Generated with [Claude Code](https://claude.com/claude-code)