### PR TITLE
onUpdate: split node-level { value } from whole-document { data } (#375)

### DIFF
--- a/.changeset/onupdate-value-data-split.md
+++ b/.changeset/onupdate-value-data-split.md
@@ -1,0 +1,9 @@
+---
+'json-edit-react': major
+---
+
+Split the `onUpdate` override return into node-level `{ value }` and whole-document `{ data }`.
+
+Returning `{ value: X }` now replaces the **edited node's** value (applied at its path), not the whole document — the common case of tidying what the user just entered (lower-case, round, trim, sort *this* array). It is honoured for `edit` and `add`; for `rename` / `move` / `delete` it has no target value and is ignored. To replace the **whole document** (stamp a top-level field, sort siblings, canonicalise the structure), return the new key `{ data: X }`, which works on every event.
+
+**Breaking.** Previously `{ value: X }` replaced the whole document. Any `onUpdate` relying on that — including whole-document timestamp/sort transforms — must switch to `{ data: X }`. Returning both keys is a mistake: `{ data }` wins, `{ value }` is ignored, and a console warning is emitted. See the [migration guide](https://github.com/CarlosNZ/json-edit-react/blob/main/migration-guide.md) (§9).

--- a/README.md
+++ b/README.md
@@ -522,7 +522,8 @@ The function can return nothing (the change proceeds as normal), or a value to a
 - `true` / `void` / `undefined`: the change proceeds as normal
 - `false`: treats the change as an error — the data is not updated (reverts to the previous value) and a generic error message is displayed in the UI
 - `null`: **silently cancels** the change — no update, and *no* error message (unlike `false`). Use this to quietly abort a change that isn't an error
-- `{ value: <value> }`: use the returned `<value>` instead of the input data. You might use this to automatically modify user input — for example, sorting an array, or inserting a timestamp field into an object
+- `{ value: <value> }`: replace the **edited node's** value with `<value>` (applied at its path). Use this to tidy what the user just entered — lower-case a string, round a number, trim, sort *this* array. Honoured for `edit` and `add`; ignored for `rename` / `move` / `delete` (those events have no node value to set)
+- `{ data: <data> }`: replace the **whole document** with `<data>`. Use this for cross-field changes — stamping a `lastModified`, sorting sibling nodes, canonicalising the structure. Works for every event. (Returning both `value` and `data` is a mistake: `data` wins and `value` is ignored, with a console warning.)
 - `{ error: <string> }` (or `{ error: { code, message } }`): treats the change as an error, with your provided message shown in the UI
 
 (Any of the above may also be returned from an `async` function / `Promise`.)

--- a/demo/src/demoData/dataDefinitions.tsx
+++ b/demo/src/demoData/dataDefinitions.tsx
@@ -245,13 +245,13 @@ export const demoDataDefinitions: Record<string, DemoData> = {
       return true
     },
     onEdit: ({ newData, path }) => {
-      if (path[0] !== 'messages' && path.length !== 3) return { value: newData }
+      if (path[0] !== 'messages' && path.length !== 3) return { data: newData }
       const parentPath = [path[0], path[1]]
       const messageObject = (newData as { messages: { [key: number]: { timeStamp: string } } })
         ?.messages?.[path[1] as number]
       messageObject.timeStamp = new Date().toISOString()
       const data = assign(newData as AssignInput, parentPath, messageObject)
-      return { value: data }
+      return { data }
     },
     onAdd: ({ path, newData }) => {
       if (path[0] === 'messages' && path.length === 2) {
@@ -259,7 +259,7 @@ export const demoDataDefinitions: Record<string, DemoData> = {
         const messages = [...(newData?.messages ?? [])]
         messages.sort((a, b) => new Date(b.timeStamp).getTime() - new Date(a.timeStamp).getTime())
         const data = assign(newData as AssignInput, 'messages', messages)
-        return { value: data }
+        return { data }
       }
       return
     },

--- a/demo/src/examples/editing-model/Example.tsx
+++ b/demo/src/examples/editing-model/Example.tsx
@@ -71,7 +71,7 @@ const MODES: { value: Mode; label: string; desc: string }[] = [
       'The save returns a replacement document. Simulates a server that ' +
       'canonicalises your data: after 3 s the whole document is replaced with ' +
       'your edit plus a fresh top-level _editedAt timestamp — showing how an ' +
-      'onUpdate `{ value }` return rewrites the result.',
+      'onUpdate `{ data }` return rewrites the whole result.',
   },
   {
     value: 'cancel-null',
@@ -173,7 +173,7 @@ export default function EditingModel() {
         case 'override':
           await wait(DELAY)
           return {
-            value: {
+            data: {
               ...(nodeData.newData as Record<string, unknown>),
               _editedAt: new Date().toLocaleTimeString(),
             },

--- a/demo/src/examples/static/on-update/Example.tsx
+++ b/demo/src/examples/static/on-update/Example.tsx
@@ -6,7 +6,8 @@ import { useEditorDefaults } from '@example-resources'
 // return a value to accept / transform / reject / cancel it.
 // Try these — each shows one of the return types:
 //
-//   - edit `username` → it's lower-cased ({ value })
+//   - edit `username` → lower-cased in place ({ value })
+//   - edit `email` (valid) → stamps `lastEdited` ({ data })
 //   - remove the "@" from `email` → rejected ({ error })
 //   - set `age` below zero → reverted (false)
 //   - delete `id` → reverted with no message (null)
@@ -16,6 +17,7 @@ interface Account {
   username: string
   email: string
   age: number
+  lastEdited?: string
 }
 
 const initialData: Account = {
@@ -29,17 +31,19 @@ const onUpdate: UpdateFunction<Account> = (props) => {
   switch (props.event) {
     case 'edit': {
       const { key, newValue, newData } = props
-      // TRANSFORM the committed value. NOTE: `{ value }` is
-      // currently a WHOLE-DOCUMENT override, so we return the
-      // full `newData` with just `username` lower-cased.
-      // TODO(#375): when `{ value }` becomes node-level this is
-      // just `{ value: newValue.toLowerCase() }`, and we'll add
-      // a `{ data }` branch to demo the whole-document override.
+      // NODE-LEVEL `{ value }`: transform just the edited node's
+      // value — applied at its own path, the rest of the doc
+      // untouched.
       if (key === 'username' && typeof newValue === 'string')
-        return { value: { ...newData, username: newValue.toLowerCase() } }
-      // CUSTOM ERROR: reject with your own message.
-      if (key === 'email' && typeof newValue === 'string' && !newValue.includes('@'))
-        return { error: 'Not a valid email address' }
+        return { value: newValue.toLowerCase() }
+      if (key === 'email' && typeof newValue === 'string') {
+        // CUSTOM ERROR: reject with your own message.
+        if (!newValue.includes('@'))
+          return { error: 'Not a valid email address' }
+        // WHOLE-DOCUMENT `{ data }`: rewrite the whole document —
+        // here, stamp a top-level `lastEdited` alongside the edit.
+        return { data: { ...newData, lastEdited: new Date().toLocaleTimeString() } }
+      }
       // GENERIC ERROR: reject, revert, show the default message.
       if (key === 'age' && typeof newValue === 'number' && newValue < 0) return false
       return // accept the change

--- a/dev-docs/EditingModel-new.md
+++ b/dev-docs/EditingModel-new.md
@@ -41,7 +41,8 @@ A single `onUpdate` prop — no separate gate prop. The model passes a control o
 ```ts
 type UpdateResult =
   | void | undefined | true            // commit
-  | { value: JsonData }                // commit, overriding the committed value
+  | { value: unknown }                 // commit, overriding the edited NODE's value (edit/add only)
+  | { data: JsonData }                 // commit, overriding the WHOLE document
   | null                               // silent cancel — revert (if already applied), no error
   | false                              // reject — revert + default error message
   | { error: string | JerError } // reject — revert + this message
@@ -142,7 +143,7 @@ startX ──▶ [submitX] ──▶ commitX ──▶ [ updateSuccess | updateE
 
 | `onUpdate` returns | events after `commitX` |
 |---|---|
-| `void`/`true`/`{ value }` | `updateSuccess` |
+| `void`/`true`/`{ value }`/`{ data }` | `updateSuccess` |
 | `false`/`{ error }`/throws | `updateError` (+ revert) |
 | `null` | none — a **cancel**: fires `cancelX` instead of `commitX` (when held); a `null` *after* an optimistic commit reverts silently |
 
@@ -286,7 +287,8 @@ reconcile({ path, token, op, result, apply, getPrev }):
 
   match result:
     void | true   → fire('updateSuccess')
-    { value }     → applyValue(path, value) ; fire('updateSuccess')
+    { value }     → applyValue(nodePath, value) ; fire('updateSuccess')   // node-level (edit/add); ignored elsewhere
+    { data }      → applyValue([], data) ; fire('updateSuccess')          // whole-document
     false|{error} → applyValue(path, getPrev()) ; fire('updateError', {error})   // buffer untouched (§9.1)
     null          → applyValue(path, getPrev())                                   // silent revert
 ```

--- a/dev-docs/MANUAL-TESTING-editing-model.md
+++ b/dev-docs/MANUAL-TESTING-editing-model.md
@@ -76,7 +76,7 @@ onUpdate={async (nodeData, { hold }) => {
     case 'override':
       await wait(DELAY)
       return {
-        value: { ...(nodeData.newData as Record<string, unknown>), _editedAt: new Date().toLocaleTimeString() },
+        data: { ...(nodeData.newData as Record<string, unknown>), _editedAt: new Date().toLocaleTimeString() },
       }
     case 'cancel-null':
       await wait(DELAY)
@@ -205,7 +205,7 @@ Proves a stale failure can't clobber a node you've reopened.
 
 ### Group H — Override / silent cancel / throw
 
-- **H1 — Override** (`TEST_MODE = 'override'`): edit a value, **Enter**. After 3 s, the doc gains/updates a top-level **`_editedAt`** field (and your typed value is kept too) — the `{ value }` return replaced the whole document. Console: `commitEdit` → `updateSuccess`.
+- **H1 — Override** (`TEST_MODE = 'override'`): edit a value, **Enter**. After 3 s, the doc gains/updates a top-level **`_editedAt`** field (and your typed value is kept too) — the `{ data }` return replaced the whole document. Console: `commitEdit` → `updateSuccess`.
 - **H2 — Silent cancel** (`TEST_MODE = 'cancel-null'`): edit a value, **Enter**. Value shows optimistically, then ~3 s later **reverts with NO error** (no red message, no toast). Console: `commitEdit` … (3 s) … *(no `update*` event)*.
 - **H3 — Throw** (`TEST_MODE = 'throw'`): edit a value, **Enter**. After 3 s it reverts and surfaces **"Simulated save failure"** (the thrown message). Console: `commitEdit` → `updateError`.
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,6 +1,11 @@
 /** @type {import('jest').Config} */
 export default {
   testEnvironment: 'jsdom',
+  // Auto-restore `jest.spyOn` spies to their original implementation after each
+  // test, so a spy installed mid-test (e.g. silencing `console.warn`) can't
+  // leak into later tests if an assertion throws before a manual restore would
+  // run.
+  restoreMocks: true,
   testMatch: [
     '<rootDir>/test/**/*.test.{ts,tsx}',
     // Workspace-package tests live under their own package (keeps the root

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -16,7 +16,7 @@ If you only have a few minutes, these are the changes most likely to affect exis
 | `enableClipboard` split into `showClipboardButton` (boolean) + `onCopy` (callback); `CopyFunction` → `OnCopyFunction`                                                                                                                                                                                   | Rename the boolean to `showClipboardButton`; move any copy callback to `onCopy` — see [`enableClipboard` split](#6-enableclipboard-split-into-showclipboardbutton--oncopy)                                                                       |
 | Several display / config props renamed                                                                                                                                                                                                                                                                  | Rename `keySort`, `rootFontSize`, `errorMessageTimeout`, `stringTruncate`, `showArrayIndices`, `arrayIndexFromOne` — see [Display / config prop renames](#7-display--config-prop-renames)                                                        |
 | Callback payloads are now a single flat `NodeData` (`currentData`→`fullData`, `currentValue`→`value`, `name`→`key`)                                                                                                                                                                                     | Rename those fields in `onUpdate` / `onChange` / `onError` / `onCollapse` / `onCopy` — see [Flat `NodeData` payloads](#8-flat-nodedata-payloads)                                                                                                 |
-| `onEdit` / `onAdd` / `onDelete` merged into one `onUpdate`, return shape unified                                                                                                                                                                                                                        | Use a single `onUpdate` and `switch (props.event)`; replace tuple / bare-string returns with `{ value }` / `{ error }` (and `null` to silently cancel) — see [One `onUpdate`](#9-one-onupdate-unified-return-shape-flat-nodedata-payloads)       |
+| `onEdit` / `onAdd` / `onDelete` merged into one `onUpdate`, return shape unified                                                                                                                                                                                                                        | Use a single `onUpdate` and `switch (props.event)`; replace tuple / bare-string returns with `{ data }` (whole-document, was `['value', …]`) / `{ value }` (node-level) / `{ error }` (and `null` to silently cancel) — see [One `onUpdate`](#9-one-onupdate-unified-return-shape-flat-nodedata-payloads)       |
 | `JerError`'s `code` union gains `RENAME_ERROR` / `MOVE_ERROR` / `CLIPBOARD_ERROR`                                                                                                                                                                                                                       | Handle the new codes only if you exhaustively `switch` on `error.code` — see [One `onUpdate`](#9-one-onupdate-unified-return-shape-flat-nodedata-payloads)                                                                                       |
 | `onEditEvent` is now a lifecycle stream `(e) => …` (was `(path, isKey) => …`); `onError` / `onCollapse` use flat `NodeData`; `onCopy.error` is a `JerError`                                                                                                                                             | `switch (e.event)` over start/confirm/cancel + delete/move; update the flat payload fields — see [Observers reshaped](#10-observers-reshaped-oneditevent-lifecycle-stream-flat-onerror--oncollapse-oncopy-error)                                 |
 | `CustomNodeDefinition` fields renamed (`element`→`component`, `customKey`→`keyComponent`, `customNodeProps`→`componentProps`, `hideKey`→`showKey` (inverted), `showInTypesSelector`→`showInTypeSelector`); type `CustomNodeProps`→`CustomComponentProps`; the component's `onError` reporter is removed | Rename the fields in your definitions and the props type in your components; replace any component `onError` call with a `throw`ing `fromStandardType` — see [`CustomNodeDefinition` field renames](#11-customnodedefinition-field-renames)      |
@@ -403,11 +403,11 @@ Renaming a key and moving a node (drag-drop) previously reached the update callb
 
 ### Unified `UpdateResult` return shape
 
-The five legacy return shapes collapse into one. The `['value', x]` / `['error', x]` tuple forms and the bare-string error are removed:
+The five legacy return shapes collapse into one. The `['value', x]` / `['error', x]` tuple forms and the bare-string error are removed, and the override key now distinguishes **node-level** from **whole-document**:
 
 ```diff
-- return ['value', sortedArray]      // override the committed value
-+ return { value: sortedArray }
+- return ['value', updatedDocument]  // override — replaced the WHOLE document
++ return { data: updatedDocument }   // whole-document override (was `['value', …]`)
 
 - return 'That value is not allowed' // reject with a message
 + return { error: 'That value is not allowed' }
@@ -415,6 +415,8 @@ The five legacy return shapes collapse into one. The `['value', x]` / `['error',
 - return ['error', 'Nope']
 + return { error: 'Nope' }           // or { error: { code, message } }
 ```
+
+The override tuple `['value', x]` always replaced the **whole document** (it ran `setData(x)`); that is now **`{ data: x }`**. The new **`{ value: x }`** means something different — the **edited node's** value, applied at its own path (for `edit` / `add` only; ignored for `rename` / `move` / `delete`) — so reach for it for the common "tidy what the user just typed" case (lower-case, round, sort *this* array) and use `{ data }` when you need to rewrite siblings or stamp a top-level field. Returning both is a mistake: `data` wins and `value` is ignored, with a console warning.
 
 `true` / `void` / `undefined` (proceed) and `false` (reject with a generic message) are unchanged. **New:** returning **`null`** silently cancels the change — no commit and *no* error message (use it to quietly abort a change that isn't an error; `false` still shows an error).
 

--- a/src/JsonEditor.tsx
+++ b/src/JsonEditor.tsx
@@ -473,7 +473,23 @@ const Editor: React.FC<
           return typeof result.error === 'string'
             ? { status: 'error', error: { code, message: result.error } }
             : { status: 'error', error: result.error }
-        if (result.value !== undefined) return { status: 'override', value: result.value as JsonData }
+        const hasData = result.data !== undefined
+        const hasValue = result.value !== undefined
+        // Returning both is a mistake — `data` (whole-document) wins, `value` is
+        // ignored. Warn so it's caught at dev time.
+        if (hasData && hasValue)
+          console.warn(
+            'json-edit-react: onUpdate returned both { value } and { data }; ' +
+              '{ data } (whole-document) takes precedence and { value } is ignored.'
+          )
+        // `{ data }` replaces the whole document — apply at the root path.
+        if (hasData) return { status: 'override', value: result.data as JsonData, path: [] }
+        // `{ value }` is the edited node's value — apply at its path. Only
+        // meaningful for `edit`/`add` (the node has a value); for
+        // `rename`/`move`/`delete` it has no target, so ignore it and commit
+        // normally. For `add`, `input.path` is the new child's full path.
+        if (hasValue && (input.event === 'edit' || input.event === 'add'))
+          return { status: 'override', value: result.value as JsonData, path: input.path }
       }
       return { status: 'commit' }
     },

--- a/src/JsonEditor.tsx
+++ b/src/JsonEditor.tsx
@@ -473,6 +473,10 @@ const Editor: React.FC<
           return typeof result.error === 'string'
             ? { status: 'error', error: { code, message: result.error } }
             : { status: 'error', error: result.error }
+        // A key set to `undefined` counts as "no override for this key" (not
+        // "override to undefined") — consistent with the protocol's top-level
+        // "undefined/void = proceed" and the `error` check above. Overriding a
+        // node *to* undefined isn't supported here; `null` overrides work.
         const hasData = result.data !== undefined
         const hasValue = result.value !== undefined
         // Returning both is a mistake — `data` (whole-document) wins, `value` is

--- a/src/contexts/EditingProvider.tsx
+++ b/src/contexts/EditingProvider.tsx
@@ -91,7 +91,10 @@ export type CommitRequest =
  *  `onUpdate`'s raw return (incl. localised reject messages) to this. */
 export type UpdateOutcome =
   | { status: 'commit' }
-  | { status: 'override'; value: JsonData }
+  // `path` is where the override applies: `[]` for a whole-document `{ data }`
+  // override, or the edited node's path for a node-level `{ value }` override.
+  // `runUpdate` resolves it (it knows the event + node); `reconcile` just applies.
+  | { status: 'override'; value: JsonData; path: CollectionKey[] }
   | { status: 'cancel' }
   | { status: 'error'; error: JerError }
 
@@ -131,7 +134,8 @@ export interface CommitPrimitives {
   /** Prepare a commit (compute `newData`, the input, and apply/revert). `null`
    *  if the target path no longer exists. */
   buildCommit: (request: CommitRequest) => BuiltCommit | null
-  /** Apply an arbitrary value at `path` (used for an `{ value }` override). */
+  /** Apply an arbitrary value at `path` (used for `{ value }`/`{ data }`
+   *  overrides — node path or root `[]` respectively). */
   applyValue: (path: CollectionKey[], value: unknown) => void
 }
 
@@ -547,10 +551,10 @@ const createEditingStore = (
         emitEvent(nodeData, 'updateError', { operation: op, error: outcome.error })
         break
       case 'override':
-        // An override replaces the WHOLE document (`onUpdate` returned a
-        // modified `newData`), not just the edited node — apply it at the root
-        // path.
-        commitRef.current?.applyValue([], outcome.value)
+        // An override applies `value` at `outcome.path`: `[]` for a whole-
+        // document `{ data }` return, or the edited node's path for a node-level
+        // `{ value }` return. `runUpdate` resolved which.
+        commitRef.current?.applyValue(outcome.path, outcome.value)
         emitEvent(nodeData, 'updateSuccess', { operation: op, ...extra })
         break
       case 'commit':

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,8 +209,18 @@ export interface JerError {
 /**
  * The one canonical update result (§17, Category 2). `void`/`undefined`/`true`
  * commit; `false` rejects with a generic error; `null` is a silent abort (no
- * commit, no error); the object form overrides the committed `value` or rejects
+ * commit, no error); the object form overrides what gets committed, or rejects
  * with a custom `error` (a bare `string` is wrapped into a `JerError`).
+ *
+ * The two override keys differ in scope:
+ * - `value` — the edited node's value, applied at its path. Mirrors the
+ *   `newValue` the callback receives. Honoured only for `edit`/`add`; ignored
+ *   for `rename`/`move`/`delete` (the commit proceeds unchanged).
+ * - `data` — the whole document, applied at the root. Mirrors `newData`. Works
+ *   on every event.
+ *
+ * Returning both is a mistake: `data` (the broader operation) wins and `value`
+ * is ignored (with a dev-time warning).
  */
 export type UpdateResult<T = JsonData> =
   | true
@@ -219,7 +229,8 @@ export type UpdateResult<T = JsonData> =
   | false
   | null
   | {
-      value?: T
+      value?: unknown
+      data?: T
       error?: string | JerError
     }
 

--- a/test/JsonEditor.test.tsx
+++ b/test/JsonEditor.test.tsx
@@ -1957,7 +1957,6 @@ describe('JsonEditor — restrictions and callbacks', () => {
     // is ignored, and a dev-time warning flags the mistake.
     await waitFor(() => expect(setData).toHaveBeenLastCalledWith({ whole: 'doc' }))
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('both'))
-    warn.mockRestore()
   })
 
   test('onUpdate returning null silently cancels: no commit, no error, input reverts', async () => {

--- a/test/JsonEditor.test.tsx
+++ b/test/JsonEditor.test.tsx
@@ -1852,10 +1852,100 @@ describe('JsonEditor — restrictions and callbacks', () => {
     expect(screen.queryByText('"rejected"')).toBeNull()
   })
 
-  test('onUpdate returning { value } passes the override straight to setData', async () => {
+  test('onUpdate returning { value } on an edit applies at the edited node, not the whole document', async () => {
     const user = userEvent.setup()
     const setData = jest.fn()
-    const onUpdate = jest.fn(() => ({ value: { x: 'OVERRIDDEN' } }))
+    const onUpdate = jest.fn(() => ({ value: 'OVERRIDDEN' }))
+    render(<JsonEditor data={{ x: 'hello', y: 'world' }} setData={setData} onUpdate={onUpdate} />)
+
+    await user.dblClick(screen.getByText('"hello"'))
+    const input = screen.getByRole('textbox')
+    await user.clear(input)
+    await user.type(input, 'whatever{Enter}')
+
+    // `{ value }` is the edited NODE's value: applied at its path (`x`), leaving
+    // the sibling untouched. A whole-document override would instead collapse
+    // the doc to the bare string 'OVERRIDDEN'.
+    await waitFor(() =>
+      expect(setData).toHaveBeenLastCalledWith({ x: 'OVERRIDDEN', y: 'world' })
+    )
+  })
+
+  test('onUpdate returning { data } replaces the whole document', async () => {
+    const user = userEvent.setup()
+    const setData = jest.fn()
+    const onUpdate = jest.fn(() => ({ data: { completely: 'different' } }))
+    render(<JsonEditor data={{ x: 'hello', y: 'world' }} setData={setData} onUpdate={onUpdate} />)
+
+    await user.dblClick(screen.getByText('"hello"'))
+    const input = screen.getByRole('textbox')
+    await user.clear(input)
+    await user.type(input, 'whatever{Enter}')
+
+    // `{ data }` is the whole document, applied at the root path.
+    await waitFor(() => expect(setData).toHaveBeenLastCalledWith({ completely: 'different' }))
+  })
+
+  test('onUpdate returning { value } on an add applies at the new child path', async () => {
+    const user = userEvent.setup()
+    const setData = jest.fn()
+    const onUpdate = jest.fn(() => ({ value: 42 }))
+    const { container } = render(
+      <JsonEditor
+        data={{ existing: 'value' }}
+        setData={setData}
+        onUpdate={onUpdate}
+        showIconTooltips
+      />
+    )
+
+    await user.click(screen.getByTitle('Add'))
+    const newKeyInput = container.querySelector('input.jer-input-new-key') as HTMLInputElement
+    await user.clear(newKeyInput)
+    await user.type(newKeyInput, 'fresh{Enter}')
+
+    // The new node is added (default `null`) then `{ value }` overrides it at
+    // the child's path — the sibling and the rest of the doc are untouched.
+    await waitFor(() => expect(setData).toHaveBeenLastCalledWith({ existing: 'value', fresh: 42 }))
+  })
+
+  test('onUpdate returning { value } on a delete is ignored — the delete still applies', async () => {
+    const user = userEvent.setup()
+    const setData = jest.fn()
+    const onUpdate = jest.fn(() => ({ value: 'ignored' }))
+    render(
+      <JsonEditor data={{ x: 'hi', y: 'bye' }} setData={setData} onUpdate={onUpdate} showIconTooltips />
+    )
+
+    const xRow = screen.getByText('"hi"').closest('.jer-component') as HTMLElement
+    await user.click(xRow.querySelector('[title="Delete"]') as HTMLElement)
+
+    // `{ value }` has no meaning for a delete: it's discarded (no override) and
+    // the node is removed as normal. `rename`/`move` share this gated branch.
+    await waitFor(() => expect(setData).toHaveBeenLastCalledWith({ y: 'bye' }))
+  })
+
+  test('onUpdate returning { data } on a delete replaces the whole document', async () => {
+    const user = userEvent.setup()
+    const setData = jest.fn()
+    const onUpdate = jest.fn(() => ({ data: { replaced: true } }))
+    render(
+      <JsonEditor data={{ x: 'hi', y: 'bye' }} setData={setData} onUpdate={onUpdate} showIconTooltips />
+    )
+
+    const xRow = screen.getByText('"hi"').closest('.jer-component') as HTMLElement
+    await user.click(xRow.querySelector('[title="Delete"]') as HTMLElement)
+
+    // `{ data }` is not gated by event — it replaces the whole document even on
+    // a structural change.
+    await waitFor(() => expect(setData).toHaveBeenLastCalledWith({ replaced: true }))
+  })
+
+  test('onUpdate returning both { value } and { data }: data wins and a warning is emitted', async () => {
+    const user = userEvent.setup()
+    const setData = jest.fn()
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const onUpdate = jest.fn(() => ({ value: 'node-level', data: { whole: 'doc' } }))
     render(<JsonEditor data={{ x: 'hello' }} setData={setData} onUpdate={onUpdate} />)
 
     await user.dblClick(screen.getByText('"hello"'))
@@ -1863,9 +1953,11 @@ describe('JsonEditor — restrictions and callbacks', () => {
     await user.clear(input)
     await user.type(input, 'whatever{Enter}')
 
-    // The user's typed value is applied optimistically, then the override wins:
-    // the last write is the override (`{ value }` replaces the whole document).
-    await waitFor(() => expect(setData).toHaveBeenLastCalledWith({ x: 'OVERRIDDEN' }))
+    // The broader operation wins: `{ data }` replaces the document, `{ value }`
+    // is ignored, and a dev-time warning flags the mistake.
+    await waitFor(() => expect(setData).toHaveBeenLastCalledWith({ whole: 'doc' }))
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('both'))
+    warn.mockRestore()
   })
 
   test('onUpdate returning null silently cancels: no commit, no error, input reverts', async () => {

--- a/test/dragAndDrop.test.tsx
+++ b/test/dragAndDrop.test.tsx
@@ -110,8 +110,9 @@ describe('Drag-and-drop: edge cases', () => {
       src: { dup: 1 },
       dst: { dup: 2 },
     }
-    // Production calls console.warn for the error; silence it here.
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    // Production calls console.warn for the error; silence it here (auto-
+    // restored after the test via Jest's `restoreMocks`).
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
     const { container } = render(
       <JsonEditor data={data} setData={setData} onError={onError} allowDrag />
     )
@@ -126,8 +127,6 @@ describe('Drag-and-drop: edge cases', () => {
     expect(setData).not.toHaveBeenCalled()
     expect(onError).toHaveBeenCalledTimes(1)
     expect(onError.mock.calls[0][0].error.code).toBe('KEY_EXISTS')
-
-    warn.mockRestore()
   })
 
   test('an onUpdate that rejects a move reverts and fires updateError', async () => {


### PR DESCRIPTION
Closes #375.

## Summary

An `onUpdate` that returns `{ value: X }` previously replaced the **whole document** with `X` (applied at the root) — the name reads like "this node's value", so returning a node value silently clobbered the entire document. This splits the two intents:

- **`{ value: X }`** → the **edited node's** value, applied at its path. The common "tidy what the user just typed" case (lower-case, round, trim, sort *this* array). Honoured for `edit` / `add`; **silently ignored** for `rename` / `move` / `delete` (no node value to set).
- **`{ data: X }`** → the **whole document** (the previous behaviour). Cross-field changes — stamping a `lastModified`, sorting siblings, canonicalising structure. Works on every event.

Returning both is a mistake: **`data` wins, `value` is ignored, and a `console.warn` is emitted.**

## How it works

`applyValue(path, value)` already existed — node-level is just `applyValue(nodePath, value)`, whole-doc is `applyValue([], data)`. The result-mapping in `runUpdate` resolves which path to use (it has the event + node in scope; for `add`, `input.path` is the new child's full path), the `override` outcome carries that path, and `reconcile` applies it.

- `src/types.ts` — `UpdateResult` object form is now `{ value?: unknown; data?: T; error? }`.
- `src/JsonEditor.tsx` — `runUpdate` maps `data`→root / `value`→node (gated to edit/add) and warns on both keys.
- `src/contexts/EditingProvider.tsx` — `override` outcome carries `path`; `reconcile` applies at it.

## Breaking change

`{ value }` no longer replaces the whole document. Any `onUpdate` relying on that (whole-document timestamp/sort transforms) must switch to `{ data }`. v2 is in beta, so now is the time. Migration-guide §9 updated; `major` changeset added.

## Tests

Rewrote the old whole-doc test and added 6 to `test/JsonEditor.test.tsx` covering the new contract: node-level edit (proves sibling preservation, not a root replace), `{ data }` whole-doc, value-on-add, value-ignored-on-delete, data-on-delete, and both-keys-warn. All 6 were confirmed to **fail for the right reason** before the fix, green after.

## Docs & demo

- README return-types list, migration-guide §9, `dev-docs/EditingModel-new.md` + `MANUAL-TESTING-editing-model.md`.
- Migrated all 5 whole-document `{ value }` sites to `{ data }` (on-update example — which also gained a node-level `{ value }` showcase + a new `{ data }` branch; editing-model "Override" mode; three in the liveData guestbook). Removed the `TODO(#375)`.

## Verification

`pnpm test` (670 pass), `pnpm compile`, `pnpm lint` all green; demo typechecks against the updated core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)