### PR TITLE
Restore collectionInner themeable element

### DIFF
--- a/.changeset/restore-collection-inner-theme.md
+++ b/.changeset/restore-collection-inner-theme.md
@@ -1,0 +1,5 @@
+---
+'json-edit-react': minor
+---
+
+Restore the `collectionInner` themeable element. It styles a collection's children-body wrapper (the `.jer-collection-inner` div, below the header row), distinct from `headerRow` (the header line) and `collection` (the whole block). A bare-string value applies as `backgroundColor`, like the other structural elements; full `CSSProperties`, style functions, and arrays work too.

--- a/README_V2.md
+++ b/README_V2.md
@@ -657,6 +657,7 @@ However, you can pass in your own theme object, or part thereof. A theme object 
       fontFamily: 'monospace',
     },
     // collection: {},
+    // collectionInner: {},
     // collectionElement: {},
     // headerRow: {},
     // valueRow: {},

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -24,7 +24,6 @@ If you only have a few minutes, these are the changes most likely to affect exis
 | Fine-grained re-rendering: object / array / function props must be referentially stable to benefit                                                                                                                                                                                                      | Keep `customNodeDefinitions`, filter functions, `translations`, etc. stable (module scope or `useMemo`); callbacks are stabilised for you — see [stable props](#13-keep-object-and-function-props-referentially-stable)                          |
 | Misc public-export changes — new `AutogrowTextArea`; `toPathString` is now `/`-encoded; `ThemeStyles` is `Partial`                                                                                                                                                                                      | Mostly additive; act only if you parse `toPathString` output or typed against a total `ThemeStyles` — see [Misc changes to public exports](#14-misc-changes-to-public-exports)                                                                   |
 | `icons` prop removed; icon glyphs move into the theme                                                                                                                                                                                                                                                   | Move the config to `theme.icons` as `IconDefinition`s (or wrap with `iconFromSvg`); rename `chevron` → `collection` — see [`icons` prop removed](#15-icons-prop-removed-themes-own-their-glyphs)                                                 |
-| Themeable elements: `collectionInner` removed; `headerRow` / `valueRow` added                                                                                                                                                                                                                           | Theme the header line via `headerRow` and leaf rows via `valueRow`; move any `collectionInner` styles to `headerRow` and/or `collection` — see [Themeable elements](#16-themeable-elements-collectioninner-removed-headerrow-and-valuerow-added) |
 
 ---
 
@@ -770,21 +769,6 @@ Gone from `json-edit-react`:
 
 - The built-in icon **components** `IconAdd`, `IconEdit`, `IconDelete`, `IconCopy`, `IconOk`, `IconCancel`, `IconChevron` and their props type `IconProps`. The built-in glyphs now live on `defaultTheme.icons` (e.g. `defaultTheme.icons.add`) if you need to reference one.
 - The `IconReplacements` type (the old `icons`-prop shape) — replaced by `IconDefinition` and `ThemeIcons`.
-
----
-
-## 16. Themeable elements: `collectionInner` removed, `headerRow` and `valueRow` added
-
-The set of styleable parts (`theme.styles` keys) gains two row-level elements and drops one.
-
-- **`headerRow`** — a collection's header line (the key + brackets row).
-- **`valueRow`** — a leaf value's row.
-
-Both accept the usual element value — a colour string (applied as background), a full `CSSProperties` object, a style function, or an array — so you can theme row backgrounds, padding, or `minHeight` per row.
-
-**`collectionInner` is removed.** It targeted the children-body wrapper as distinct from the header; that distinction is now expressed more directly with `headerRow` (style the header) plus `collection` (style the whole block). If a theme set `collectionInner`, move those styles to `headerRow` and/or `collection`.
-
-`collection`, `collectionElement`, and `dropZone` are unchanged.
 
 ---
 

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -678,6 +678,7 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
           overflowY: isCollapsed || isAnimating ? 'clip' : 'visible',
           // Prevent collapse if this node or any children are being edited
           maxHeight: childrenEditing ? undefined : maxHeight,
+          ...getStyles('collectionInner', nodeData),
           transition: cssTransitionValue,
         }}
         ref={contentRef}

--- a/src/contexts/ThemeProvider/compileStyles.ts
+++ b/src/contexts/ThemeProvider/compileStyles.ts
@@ -16,6 +16,7 @@ import { toArray } from '../../utils/misc'
 const DEFAULT_PROP: Partial<Record<ThemeableElement, keyof CSSProperties>> = {
   container: 'backgroundColor',
   collection: 'backgroundColor',
+  collectionInner: 'backgroundColor',
   collectionElement: 'backgroundColor',
   headerRow: 'backgroundColor',
   valueRow: 'backgroundColor',

--- a/src/contexts/ThemeProvider/defaultTheme.tsx
+++ b/src/contexts/ThemeProvider/defaultTheme.tsx
@@ -94,6 +94,7 @@ export const defaultTheme: Theme = {
       fontFamily: 'monospace',
     },
     // collection: {},
+    // collectionInner: {},
     // collectionElement: {},
     // headerRow: {},
     // valueRow: {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -660,6 +660,7 @@ export interface InputProps {
 export type ThemeableElement =
   | 'container'
   | 'collection'
+  | 'collectionInner'
   | 'collectionElement'
   | 'headerRow'
   | 'valueRow'

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -55,6 +55,10 @@ describe('compileStyles — shorthand & merge over default', () => {
     // other structural elements.
     expect(compileStyles({ headerRow: '#eee' }).headerRow).toEqual({ backgroundColor: '#eee' })
     expect(compileStyles({ valueRow: '#eee' }).valueRow).toEqual({ backgroundColor: '#eee' })
+    // The children-body wrapper does too.
+    expect(compileStyles({ collectionInner: '#eee' }).collectionInner).toEqual({
+      backgroundColor: '#eee',
+    })
   })
 
   it('merges an object value over the default, keeping unspecified props', () => {


### PR DESCRIPTION
Re-adds the `collectionInner` themeable element (styles the `.jer-collection-inner` children-body wrapper) — additive alongside the existing `headerRow`/`valueRow`. Removing it in #370 was a mistake.

Includes default-theme/README entries, a `theme.test.ts` case, removal of the now-moot migration-guide §16, and a `minor` changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)