### PR TITLE
Keep live child rows during edit for showOnEdit collection custom nodes (#384)

### DIFF
--- a/.changeset/collection-children-on-edit.md
+++ b/.changeset/collection-children-on-edit.md
@@ -1,0 +1,5 @@
+---
+'json-edit-react': minor
+---
+
+A **collection** custom `component` with `showOnEdit: true` now receives the live child rows as its `children` while editing — the same as in view — instead of the built-in raw-JSON `<textarea>` editor. This lets such a node compose an editable header/toolbar above rows that stay visible and interactive throughout the edit; it owns its commit affordance (`setIsEditing` / `handleEdit` / `handleCancel`) and edits the collection through `setValue`. To edit the whole subtree as raw JSON inside a custom component, render your own editor and commit a parsed value via `setValue` (the public `AutogrowTextArea` is exported for the built-in textarea's look). Collection components with `showOnEdit` falsy are unaffected and still fall through to the built-in JSON editor.

--- a/README_V2.md
+++ b/README_V2.md
@@ -1151,12 +1151,16 @@ The collection-specific details:
   <img width="450" alt="custom node levels" src="image/custom_component_levels.png">
 
 - `showCollectionWrapper: false` is the full-replacement escape hatch — no chevron, brackets, or built-in collapse, so you're responsible for completely rendering the data within.
+- With `showOnEdit: true` your `component` owns the node's editor, so it keeps receiving the live child rows as `children` _while editing_ too (the same as in view) rather than the built-in JSON textarea. It supplies its own commit affordance — `setIsEditing` to open the session, `handleEdit` / `handleCancel` to close it — and edits the collection through `setValue`. This lets a node compose an editable header or toolbar above rows that stay visible and interactive throughout the edit.
 
 See the different "wrapper" and "inner" component elements in use:  
 [![▶ Live example: Custom collection nodes](https://img.shields.io/badge/▶_Live_example-Custom_collection_nodes-2ea44f?style=for-the-badge)](https://carlosnz.github.io/json-edit-react-v2/examples/custom-collection-nodes)
 
 A "full-takeover" example:  
 [![▶ Live example: Student ID cards](https://img.shields.io/badge/▶_Live_example-Student_ID_cards-2ea44f?style=for-the-badge)](https://carlosnz.github.io/json-edit-react-v2/examples/student-cards)
+
+A `showOnEdit` collection whose header/toolbar stays live above editable rows:  
+[![▶ Live example: Playlist](https://img.shields.io/badge/▶_Live_example-Playlist-2ea44f?style=for-the-badge)](https://carlosnz.github.io/json-edit-react-v2/examples/playlist)
 
 ### Displaying a collection as a value
 

--- a/demo/src/examples/registry.ts
+++ b/demo/src/examples/registry.ts
@@ -285,6 +285,16 @@ const allExamples: Record<string, ExampleDef> = {
     load: () => import('./static/custom-collection-nodes/Example'),
     code: () => import('./static/custom-collection-nodes/Example.tsx?raw'),
   },
+  playlist: {
+    kind: 'static',
+    title: 'Playlist',
+    blurb:
+      'A custom **collection** node that owns its editor (`showOnEdit: true`) keeps the live child rows as its `children` *while editing*, just as in view — so it can place an editable header or toolbar **above** the rows and keep them interactive the whole time, instead of being handed the built-in JSON textarea.\n\n' +
+      "Here `tracks` is the custom node: its header shows the track count and total runtime, and **Reorder…** opens the node's own edit session, swapping the header for a Shuffle / Sort / Reverse toolbar — each commits a reordered array through `setValue`, no special editor prop required.\n\n" +
+      'Try it while the toolbar is open: the track rows stay fully editable. Change a title or `seconds` inline and, because there is a single active edit session, doing so simply displaces the header’s session.',
+    load: () => import('./static/playlist/Example'),
+    code: () => import('./static/playlist/Example.tsx?raw'),
+  },
   'student-cards': {
     kind: 'static',
     title: 'Student ID cards',

--- a/demo/src/examples/static/playlist/Example.tsx
+++ b/demo/src/examples/static/playlist/Example.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react'
+import {
+  JsonEditor,
+  type CustomComponentProps,
+  type CustomNodeDefinition,
+  type JsonData,
+} from '@json-edit-react'
+import { useEditorDefaults } from '@example-resources'
+
+// A custom COLLECTION node that owns its own editor (`showOnEdit:
+// true`) keeps the live child rows as its `children` while editing
+// — exactly as in view — instead of being handed the built-in
+// JSON textarea. So it can put an editable header/toolbar ABOVE
+// the rows and keep them visible and interactive the whole time.
+//
+// Here `tracks` is the custom node. Its header shows the track
+// count and total runtime; clicking "Reorder…" opens the node's
+// own edit session, swapping the header for a toolbar (Shuffle /
+// Sort / Reverse). Each action commits a reordered array through
+// `setValue` — no special editor prop is needed.
+//
+// While that toolbar is open the track rows stay fully editable:
+// edit a track's title or seconds inline, and (because there's a
+// single active edit session) doing so just displaces the header's
+// session. `showCollectionWrapper: false` drops the array's
+// brackets/chevron so the header stands in for them.
+
+interface Track {
+  title: string
+  artist: string
+  seconds: number
+}
+
+const initialData = {
+  title: 'Focus Flow',
+  tracks: [
+    { title: 'Clair de Lune', artist: 'Debussy', seconds: 312 },
+    { title: 'Gymnopédie No. 1', artist: 'Satie', seconds: 210 },
+    { title: 'Spiegel im Spiegel', artist: 'Pärt', seconds: 540 },
+  ],
+}
+
+// A faint neutral overlay that composites over any theme.
+const PANEL = 'rgba(127, 127, 127, 0.08)'
+const BORDER = 'rgba(127, 127, 127, 0.22)'
+
+const formatDuration = (totalSeconds: number) => {
+  const mins = Math.floor(totalSeconds / 60)
+  const secs = totalSeconds % 60
+  return `${mins}:${String(secs).padStart(2, '0')}`
+}
+
+// Fisher–Yates; runs in the browser, so Math.random is fine.
+const shuffle = (tracks: Track[]) => {
+  const next = [...tracks]
+  for (let i = next.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[next[i], next[j]] = [next[j], next[i]]
+  }
+  return next
+}
+
+const TrackList = ({
+  value,
+  children,
+  isEditing,
+  setIsEditing,
+  setValue,
+  handleCancel,
+  getStyles,
+  nodeData,
+}: CustomComponentProps) => {
+  const tracks = (value ?? []) as unknown as Track[]
+  const accent = getStyles('number', nodeData).color ?? '#268bd2'
+  const total = formatDuration(
+    tracks.reduce((sum, track) => sum + (Number(track?.seconds) || 0), 0)
+  )
+
+  // Commit a reordered list; this closes the session, so each
+  // action is one-shot (re-open "Reorder…" to run another).
+  const reorder = (next: Track[]) => setValue(next as unknown as JsonData)
+
+  const button = {
+    background: PANEL,
+    border: `1px solid ${BORDER}`,
+    borderRadius: 6,
+    padding: '0.15em 0.6em',
+    fontSize: '0.8em',
+    cursor: 'pointer',
+    color: 'inherit',
+  }
+
+  return (
+    <div
+      style={{
+        background: PANEL,
+        border: `1px solid ${BORDER}`,
+        borderRadius: 10,
+        padding: '0.5em 0.8em',
+        margin: '0.3em 0 0.8em',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '0.6em',
+          marginBottom: '0.4em',
+        }}
+      >
+        <span style={{ fontFamily: 'sans-serif', fontWeight: 700, color: accent }}>
+          🎵 {tracks.length} tracks · {total}
+        </span>
+        {isEditing ? (
+          <div style={{ display: 'flex', gap: '0.4em' }}>
+            <button style={button} onClick={() => reorder(shuffle(tracks))}>
+              Shuffle
+            </button>
+            <button
+              style={button}
+              onClick={() => reorder([...tracks].sort((a, b) => a.seconds - b.seconds))}
+            >
+              Sort by length
+            </button>
+            <button style={button} onClick={() => reorder([...tracks].reverse())}>
+              Reverse
+            </button>
+            <button style={{ ...button, fontWeight: 700 }} onClick={handleCancel}>
+              Done
+            </button>
+          </div>
+        ) : (
+          <button style={button} onClick={() => setIsEditing(true)}>
+            Reorder…
+          </button>
+        )}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+const customNodeDefinitions: CustomNodeDefinition[] = [
+  {
+    condition: ({ key }) => key === 'tracks',
+    component: TrackList,
+    showOnView: true,
+    showOnEdit: true, // the node owns its editor (header + live rows)
+    showCollectionWrapper: false, // drop the array's brackets/chevron
+  },
+]
+
+export default function Playlist() {
+  const [data, setData] = useState<JsonData>(initialData)
+
+  return (
+    <JsonEditor
+      data={data}
+      setData={setData}
+      {...useEditorDefaults()}
+      rootName="playlist"
+      customNodeDefinitions={customNodeDefinitions}
+    />
+  )
+}

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -595,6 +595,10 @@ If your v1 component **called** the error reporter to reject invalid input, that
 + }
 ```
 
+### Collection `component` with `showOnEdit: true` receives the live child rows while editing
+
+If a **collection** custom `component` set `showOnEdit: true`, it was handed the built-in raw-JSON `<textarea>` editor as its `children` while editing. It now receives the live child rows instead — the same `children` as in view — so it can keep the rows visible and editable beneath its own header/toolbar. The component supplies its own commit affordance (`setIsEditing` / `handleEdit` / `handleCancel`) and edits the collection via `setValue`. Only act if you relied on the old behaviour: to edit the whole subtree as raw JSON inside your component, render your own editor and commit a parsed value through `setValue` (the public `AutogrowTextArea` is exported if you want the built-in textarea's look). Custom collection components with `showOnEdit` falsy are unaffected — they still fall through to the built-in JSON editor.
+
 ---
 
 ## 12. `externalTriggers` prop replaced by the `editorRef` imperative handle

--- a/src/CollectionNode.tsx
+++ b/src/CollectionNode.tsx
@@ -394,7 +394,16 @@ const CollectionNodeBase: React.FC<CollectionNodeProps> = (props) => {
 
   if (collectionType === 'object') sort<[string | number, ValueData]>(keyValueArray, (_) => _)
 
-  const CollectionChildren = !hasBeenOpened.current ? null : !isEditing ? (
+  // A custom component with `showOnEdit` owns this node's editor, so it
+  // receives the live child rows as `children` in edit mode too (same as
+  // view) — never the built-in JSON textarea. The textarea only renders for
+  // standard collection editing (no custom editor for the editing state); its
+  // buffer/parse plumbing (`editBufferValue`/`handleEdit`) simply goes unused
+  // for these nodes.
+  const customOwnsEdit = !!CustomComponent && showOnEdit
+  const showChildRows = !isEditing || customOwnsEdit
+
+  const CollectionChildren = !hasBeenOpened.current ? null : showChildRows ? (
     keyValueArray.map(([key, value], index) => {
       const childNodeData = {
         key,

--- a/test/customNode.test.tsx
+++ b/test/customNode.test.tsx
@@ -194,6 +194,66 @@ describe('CustomNode — view/edit visibility', () => {
   })
 })
 
+describe('CustomNode — collection editor keeps live children (#384)', () => {
+  // A collection custom component that renders its own header above the live
+  // child rows (`children`). The header marker opens this node's own edit
+  // session via `setIsEditing`, mirroring a real toolbar/header node.
+  const CollectionEditor = ({ children, isEditing, setIsEditing }: CustomComponentProps) => (
+    <div>
+      <span data-testid="open" onDoubleClick={() => setIsEditing(true)}>
+        {isEditing ? 'EDITING' : 'VIEW'}
+      </span>
+      {children}
+    </div>
+  )
+
+  const collectionDef = (overrides: Partial<CustomNodeDefinition> = {}): CustomNodeDefinition => ({
+    condition: ({ key }) => key === 'group',
+    component: CollectionEditor,
+    ...overrides,
+  })
+
+  test('showOnEdit true → children stay the live child rows while editing (not the JSON textarea)', async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <JsonEditor
+        data={{ group: { a: 'alpha', b: 'beta' } }}
+        setData={noop}
+        customNodeDefinitions={[collectionDef({ showOnEdit: true })]}
+      />
+    )
+    // View: the custom header sits above the live child rows.
+    expect(screen.getByText('VIEW')).toBeInTheDocument()
+    expect(screen.getByText('"alpha"')).toBeInTheDocument()
+    expect(screen.getByText('"beta"')).toBeInTheDocument()
+
+    await user.dblClick(screen.getByTestId('open'))
+
+    // The component owns the edit state — and its `children` is STILL the live
+    // child rows, never the built-in raw-JSON textarea.
+    expect(screen.getByText('EDITING')).toBeInTheDocument()
+    expect(screen.getByText('"alpha"')).toBeInTheDocument()
+    expect(screen.getByText('"beta"')).toBeInTheDocument()
+    expect(container.querySelector('.jer-collection-text-area')).toBeNull()
+  })
+
+  test('showOnEdit false → standard collection editing still yields the JSON textarea', async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <JsonEditor
+        data={{ group: { a: 'alpha' } }}
+        setData={noop}
+        customNodeDefinitions={[collectionDef()]}
+      />
+    )
+    await user.dblClick(screen.getByTestId('open'))
+    // The custom component doesn't render the edit state, so the built-in
+    // textarea takes over — unaffected by the showOnEdit-true change.
+    expect(container.querySelector('.jer-collection-text-area')).not.toBeNull()
+    expect(screen.queryByTestId('open')).toBeNull()
+  })
+})
+
 describe('CustomNode — chrome flags', () => {
   test('showKey default true → the key is rendered alongside the custom component', () => {
     render(


### PR DESCRIPTION
Closes #384.

## What

When a **collection** custom node owns its editor (`showOnEdit: true` + a custom `component`), its `children` now stays the **live child rows while editing** — the same as in view — instead of being swapped for the built-in raw-JSON `<textarea>`. This is the new default: `showOnEdit: true` already means "I supply this node's editor", so handing it the library's own textarea as `children` was incoherent.

This lets a node compose `toolbar + {children}` in both states and lean entirely on the built-in `EditingProvider` — e.g. an Operator/Fragment-style header that keeps its children visible and interactive while the header is in edit mode.

## How

[`src/CollectionNode.tsx`](../blob/348-pass-normal-children-to-custom-collection-node-if-showOnEdit-is-false/src/CollectionNode.tsx): a `customOwnsEdit = !!CustomComponent && showOnEdit` predicate gates `CollectionChildren` so the live child rows render whenever the custom component owns the edit state. The existing child-rows JSX is reused verbatim; the textarea branch (and its OK/Cancel buttons) only fires for standard collection editing. The buffer/parse plumbing (`editBufferValue` / `handleEdit`) simply goes unused for these nodes — nothing removed.

No new prop. A custom editor commits collection-level changes via the `setValue` it already receives, and owns its commit affordance (`setIsEditing` / `handleEdit` / `handleCancel`). The public `AutogrowTextArea` remains exported for anyone who wants the built-in textarea's look.

## Compatibility

Behaviour change for an existing `showOnEdit: true` **collection** custom node that rendered `{children}` expecting the JSON textarea — it now gets the live rows. The one genuinely removed capability is "custom chrome wrapped around the built-in JSON textarea editor"; `showOnEdit: false` is **not** an equivalent (it drops the custom component entirely during edit). The changeset and migration-guide note say this explicitly. Acceptable in v2-beta.

## Example

New **Playlist** example page: `tracks` is a `showOnEdit: true` custom node whose header shows count + runtime and a "Reorder…" toolbar (Shuffle / Sort / Reverse, committing via `setValue`) that appears while the track rows stay live and editable beneath it. Editing a track inline during the header session simply displaces it (single active session).

## Tests

- Regression test (rows present + textarea absent during a `showOnEdit:true` collection edit; fails before the fix at exactly the right line).
- `showOnEdit:false` guard (standard collection editing still yields the textarea).
- Full suite green (672 passing), lint clean, `tsc` clean for core **and** demo.

## Not yet done

Interactive browser click-through wasn't possible in this environment — verified the dev server boots and the example module transforms without errors, but the manual "click Reorder, edit a track inline, watch the session displace" walkthrough is the remaining check.

> **Note:** the branch name says `…if-showOnEdit-is-false`, but the implemented behaviour (per #384) triggers when `showOnEdit` is **true** — likely a stale name carried from #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)