### PR TITLE
Resolve synchronous onUpdate verdicts in place (no setData write on sync reject)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # json-edit-react
 
+## 2.0.0-beta.8
+
+- A **synchronous** `onUpdate` rejection (`false`, `{ error }`, or a thrown error) now resolves in place rather than applying optimistically and then reverting. The rejected value is never written through `setData`, so it no longer flashes in the editor and leaves nothing transient for downstream state (an undo history, autosave, a dirty flag) to pick up. Asynchronous rejections are unchanged — they still commit optimistically and revert when the promise settles (#391).
+- As a result, the `onEditEvent` lifecycle for a synchronously-rejected edit / rename / add is now `submit* → cancel* → updateError` (no `commit*`), matching how the instant operations (delete, move) already report a fast rejection.
+
 ## 2.0.0-beta.7
 
 - A custom node definition's `defaultValue` can now be a function `(nodeData) => value`, called each time a node is switched to that type — the same callback form the editor-level `defaultValue` prop already supports. Use it for a fresh value (e.g. `() => new Date()`) instead of one fixed when the module loads. Plain values keep working unchanged.

--- a/README_V2.md
+++ b/README_V2.md
@@ -272,7 +272,9 @@ More detail [below](#programmatic-control)
 
 ### Controlled component — `data` + `setData`
 
-You manage the `data` state yourself outside this component and pass in a `setData` method, which is called internally to update your `data`. 
+You manage the `data` state yourself outside this component and pass in a `setData` method, which is called internally to update your `data`.
+
+Keep the two channels distinct: **`data`/`setData` are your local UI state** (the document the editor renders and the setter it calls), while **`onUpdate` is for *external* writes and side effects** — persisting to a server, validation, notifications, mutating-before-save. Don't reach for `onUpdate` to drive local state (that's `setData`'s job), and don't treat raw `setData` calls as "saves": under the [optimistic model](#async-updates--gating--hold) an *asynchronous* `onUpdate` lets `setData` fire for a value that's still in flight or about to be reverted, so anything that must react only to *settled* changes (autosave, an undo stack, a dirty flag) should key off `onUpdate` or the [`updateSuccess`/`updateError`](#listening-to-the-lifecycle--oneditevent) events, not raw `setData`.
 
 ### Read-only display — `JsonViewer`
 
@@ -539,9 +541,9 @@ The function can return nothing (the change proceeds as normal), or a value to a
 
 ### Async updates & gating — `hold()`
 
-By default, commits are **optimistic**: when the user submits an edit the input closes and the data updates immediately, then `onUpdate` runs in the background. If it rejects (`false`, `{ error }`, a thrown error, or a rejected promise), the change is automatically reverted and the error surfaced. A slow `onUpdate` — say a network save — therefore never blocks the editor, and the user can keep working. Each in-flight commit is tracked independently, so a late failure reverts only its own node and can't clobber a newer edit.
+Whether a commit is **optimistic** depends on your `onUpdate`. A **synchronous** `onUpdate` — the typical case for local or [JSON-Schema](#json-schema-validation) validation — is resolved *in place*: a valid edit commits, and a rejected one (`false`, `{ error }`, or a thrown error) is simply never applied, so the input reverts and the error shows with no transient write to your `data`. An **asynchronous** `onUpdate` (e.g. a network save) can't be known in time, so the commit is **optimistic**: the input closes and the data updates immediately, then `onUpdate` runs in the background and a rejection (including a rejected promise) is automatically reverted and the error surfaced. A slow `onUpdate` therefore never blocks the editor, and the user can keep working. Each in-flight commit is tracked independently, so a late failure reverts only its own node and can't clobber a newer edit.
 
-Structural changes — **delete**, drag-and-drop **move**, and adding an **array** item — settle a little differently. With no open input to keep responsive, they wait a brief moment (~100ms) for `onUpdate`: a fast result (e.g. synchronous schema validation) applies or rejects *in place*, so a rejected delete keeps the node and shows its error immediately; only a slow `onUpdate` falls back to the optimistic path (apply, then revert on failure). A rejected **move** has no settled position to anchor an inline message to, so it reports through the [`onEditEvent`](#listening-to-the-lifecycle--oneditevent) `updateError` event rather than an inline error.
+Structural changes — **delete**, drag-and-drop **move**, and adding an **array** item — have no open input to keep responsive, so an *asynchronous* `onUpdate` waits a brief moment (~100ms) before applying optimistically: a result that arrives inside that window settles *in place* (the node is never removed/relocated, so a rejected delete keeps the node and shows its error immediately), and only a slower one falls back to apply-then-revert. A rejected **move** has no settled position to anchor an inline message to, so it reports through the [`onEditEvent`](#listening-to-the-lifecycle--oneditevent) `updateError` event rather than an inline error.
 
 If instead you want to **hold the editor open** until a decision resolves — e.g. to show a confirmation dialog, or to validate before the value is committed — call `hold()` on the second argument:
 
@@ -1304,7 +1306,7 @@ The `onEditEvent` callback streams the complete **interaction lifecycle**. It re
 | Save settled          | `updateSuccess` *or* `updateError`                                  | Only fired when an `onUpdate` ran; carries the `operation` (and, on error, the `error`) |
 
 A few things worth knowing:
-- A session ends with **exactly one** of `commit*` (applied) or `cancel*` (closed without applying) — and `cancel*` also fires when `onUpdate` returns `null`, not only on an explicit cancel.
+- A session ends with **exactly one** of `commit*` (applied) or `cancel*` (closed without applying). `cancel*` also fires when `onUpdate` returns `null`, and when a **synchronous** `onUpdate` rejects (`false` / `{ error }` / throw) — a sync verdict is known before the optimistic apply, so the session closes via `cancel*` (+ `updateError`) rather than `commit*`. An *asynchronous* reject still emits `commit*` first (the optimistic apply), then `updateError`.
 - A [`hold()` gate](#async-updates--gating--hold), if you've set one, runs in the `submit*` window.
 - **Add events describe the parent collection** (the node you're adding *into*); `commitAdd` is where the add lands.
 - **Array adds are instant** — they emit only `commitAdd` (no `startAdd`/`submitAdd`/`cancelAdd`, since there's no key-entry step).

--- a/src/JsonEditor.tsx
+++ b/src/JsonEditor.tsx
@@ -13,7 +13,7 @@ import { CollectionNode } from './CollectionNode'
 import { NativeSelect } from './NativeSelect'
 import { getFullKeyboardControlMap, handleKeyPress } from './utils/keyboard'
 import { computeFilterState, matchNode, matchNodeKey } from './utils/filter'
-import { isCollection, NOOP, restoreUndefined, UNDEFINED } from './utils/misc'
+import { isCollection, isThenable, NOOP, restoreUndefined, UNDEFINED } from './utils/misc'
 import {
   type CollectionData,
   type JsonEditorProps,
@@ -22,6 +22,7 @@ import {
   type SearchFilterFunction,
   type CollectionKey,
   type UpdateFunctionProps,
+  type UpdateResult,
   type UpdateControl,
   type JerErrorCode,
   type SortFunction,
@@ -470,17 +471,25 @@ const Editor: React.FC<
   // event-specific reject message (so it matches the `onError` code the node
   // surfaces). This is the old synchronous result-protocol, minus `setData`
   // (now the engine's job).
+  //
+  // Returns the outcome SYNCHRONOUSLY when `onUpdate` does (a non-thenable
+  // return), and a promise only when it's genuinely async. The engine uses
+  // that distinction to skip the optimistic apply for a synchronous verdict —
+  // so a sync reject never writes to `setData`. (We call `onUpdate` directly
+  // rather than `await`-ing it; an `async` wrapper would force even a sync
+  // return into a microtask, after the optimistic apply has already fired.)
   const runUpdate = useCallback(
-    async (input: UpdateFunctionProps, control: UpdateControl): Promise<UpdateOutcome> => {
+    (
+      input: UpdateFunctionProps,
+      control: UpdateControl
+    ): UpdateOutcome | Promise<UpdateOutcome> => {
       const code = ERROR_CODE[input.event]
       const defaultMessage = () =>
         translateRef.current(ERROR_MESSAGE_KEY[input.event], rootNodeDataRef.current)
-      let result
-      try {
-        result = await onUpdateRef.current(input, control)
-      } catch (err) {
-        // Rejected promise → treat as a reject; surface the thrown message if
-        // present (also stops it escaping as an unhandled rejection).
+
+      // Thrown sync error / rejected promise → a reject, surfacing the message
+      // if present (also stops a rejection escaping as unhandled).
+      const toError = (err: unknown): UpdateOutcome => {
         const message =
           err instanceof Error && err.message
             ? err.message
@@ -489,36 +498,48 @@ const Editor: React.FC<
               : defaultMessage()
         return { status: 'error', error: { code, message } }
       }
-      if (result === false) return { status: 'error', error: { code, message: defaultMessage() } }
-      if (result === null) return { status: 'cancel' }
-      if (result && typeof result === 'object') {
-        if (result.error !== undefined)
-          return typeof result.error === 'string'
-            ? { status: 'error', error: { code, message: result.error } }
-            : { status: 'error', error: result.error }
-        // A key set to `undefined` counts as "no override for this key" (not
-        // "override to undefined") — consistent with the protocol's top-level
-        // "undefined/void = proceed" and the `error` check above. Overriding a
-        // node *to* undefined isn't supported here; `null` overrides work.
-        const hasData = result.data !== undefined
-        const hasValue = result.value !== undefined
-        // Returning both is a mistake — `data` (whole-document) wins, `value`
-        // is ignored. Warn so it's caught at dev time.
-        if (hasData && hasValue)
-          console.warn(
-            'json-edit-react: onUpdate returned both { value } and { data }; ' +
-              '{ data } (whole-document) takes precedence and { value } is ignored.'
-          )
-        // `{ data }` replaces the whole document — apply at the root path.
-        if (hasData) return { status: 'override', value: result.data as JsonData, path: [] }
-        // `{ value }` is the edited node's value — apply at its path. Only
-        // meaningful for `edit`/`add` (the node has a value); for
-        // `rename`/`move`/`delete` it has no target, so ignore it and commit
-        // normally. For `add`, `input.path` is the new child's full path.
-        if (hasValue && (input.event === 'edit' || input.event === 'add'))
-          return { status: 'override', value: result.value as JsonData, path: input.path }
+
+      const normalise = (result: UpdateResult): UpdateOutcome => {
+        if (result === false) return { status: 'error', error: { code, message: defaultMessage() } }
+        if (result === null) return { status: 'cancel' }
+        if (result && typeof result === 'object') {
+          if (result.error !== undefined)
+            return typeof result.error === 'string'
+              ? { status: 'error', error: { code, message: result.error } }
+              : { status: 'error', error: result.error }
+          // A key set to `undefined` counts as "no override for this key"
+          // (not "override to undefined") — consistent with the protocol's
+          // top-level "undefined/void = proceed" and the `error` check above.
+          // Overriding a node *to* undefined isn't supported here; `null`
+          // overrides work.
+          const hasData = result.data !== undefined
+          const hasValue = result.value !== undefined
+          // Returning both is a mistake — `data` (whole-document) wins, `value`
+          // is ignored. Warn so it's caught at dev time.
+          if (hasData && hasValue)
+            console.warn(
+              'json-edit-react: onUpdate returned both { value } and { data }; ' +
+                '{ data } (whole-document) takes precedence and { value } is ignored.'
+            )
+          // `{ data }` replaces the whole document — apply at the root path.
+          if (hasData) return { status: 'override', value: result.data as JsonData, path: [] }
+          // `{ value }` is the edited node's value — apply at its path. Only
+          // meaningful for `edit`/`add` (the node has a value); for
+          // `rename`/`move`/`delete` it has no target, so ignore it and commit
+          // normally. For `add`, `input.path` is the new child's full path.
+          if (hasValue && (input.event === 'edit' || input.event === 'add'))
+            return { status: 'override', value: result.value as JsonData, path: input.path }
+        }
+        return { status: 'commit' }
       }
-      return { status: 'commit' }
+
+      let raw
+      try {
+        raw = onUpdateRef.current(input, control)
+      } catch (err) {
+        return toError(err)
+      }
+      return isThenable(raw) ? raw.then(normalise, toError) : normalise(raw as UpdateResult)
     },
     []
   )

--- a/src/contexts/EditingProvider.tsx
+++ b/src/contexts/EditingProvider.tsx
@@ -48,6 +48,7 @@ import {
 } from '../types'
 import { type AssignOptions } from '../utils/assign'
 import { isDescendantOf, pathsEqual, toPathString } from '../utils/pathTools'
+import { isThenable } from '../utils/misc'
 
 type Token = number
 type PathString = string
@@ -129,9 +130,14 @@ export interface BuiltCommit {
  */
 export interface CommitPrimitives {
   /** Run the consumer's `onUpdate` and normalise its result to an outcome.
-   *  `undefined` when no `onUpdate` was supplied (the engine then skips the
-   *  settlement phase — no `update*`). */
-  runUpdate?: (input: UpdateFunctionProps, control: UpdateControl) => Promise<UpdateOutcome>
+   *  Returns the outcome SYNCHRONOUSLY when `onUpdate` does, a promise only
+   *  when it's async — the engine skips the optimistic apply for a synchronous
+   *  verdict. `undefined` when no `onUpdate` was supplied (the engine then
+   *  skips the settlement phase — no `update*`). */
+  runUpdate?: (
+    input: UpdateFunctionProps,
+    control: UpdateControl
+  ) => UpdateOutcome | Promise<UpdateOutcome>
   /** Prepare a commit (compute `newData`, the input, and apply/revert). `null`
    *  if the target path no longer exists. */
   buildCommit: (request: CommitRequest) => BuiltCommit | null
@@ -478,7 +484,21 @@ const createEditingStore = (
       return Promise.resolve(undefined)
     }
 
-    const promise = prims!.runUpdate!(input, control)
+    const result = prims!.runUpdate!(input, control)
+    const isAsync = isThenable(result)
+
+    // Synchronous verdict on an editor op: we know the outcome in this tick, so
+    // skip the optimistic apply entirely. `reconcile` applies for commit/
+    // override and stays put for error/cancel — so a synchronous reject never
+    // writes to `setData` (no value-flash, clean undo history). Held + instant
+    // ops keep the optimistic/timer path below: instant ops already pre-empt a
+    // sync reject via the timer, and a `hold()` gate is async by design.
+    if (!held && !instant && !isAsync) {
+      return Promise.resolve(
+        reconcile(path, op, token, result, apply, revert, () => applied, nodeData, extra)
+      )
+    }
+
     // Editor ops (edit/rename/object-add) apply immediately: the node survives
     // a later revert (so a rejection's inline error still shows) and Tab/close
     // must feel instant. INSTANT ops (delete/move/array-add) defer the
@@ -487,6 +507,7 @@ const createEditingStore = (
     // rejection's inline error renders on it (a V1 behaviour the
     // always-optimistic path lost). A slow `onUpdate` still applies
     // optimistically once the timer fires.
+    const promise = isAsync ? result : Promise.resolve(result)
     let optimisticTimer: ReturnType<typeof setTimeout> | undefined
     if (!held) {
       if (instant) optimisticTimer = setTimeout(apply, OPTIMISTIC_DELAY_MS)
@@ -515,11 +536,20 @@ const createEditingStore = (
   ): UpdateOutcome | undefined => {
     const pathStr = toPathString(path)
 
-    // Held-without-release: this resolve IS the apply/close moment.
+    // Pre-apply: this resolve IS the apply/close moment. Two ways to land here
+    // without an optimistic apply — a held gate releasing, or a synchronous
+    // editor-op verdict (the sync fast-path in `submit`).
     if (!applied()) {
       if (outcome.status === 'cancel' || outcome.status === 'error') {
-        // Gate declined (or rejected) before applying → cancel the session.
-        if (state.active?.phase === 'held' && pathsEqual(state.active.path, path)) {
+        // Declined/rejected before applying → close the still-open session: a
+        // 'held' gate, OR a non-held 'editing' session left open by the sync
+        // fast-path. Closing it lets the node revert + report the error
+        // (`settleEdit` sees `active === null`), like the post-apply revert.
+        if (
+          state.active &&
+          pathsEqual(state.active.path, path) &&
+          (state.active.phase === 'held' || state.active.phase === 'editing')
+        ) {
           commit({ ...state, active: null })
           cancelOp = null
           commitOp = null

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -21,6 +21,14 @@ export const isCollection = (value: unknown): value is Record<string, unknown> |
 export const isObject = (input: unknown): input is Record<string, unknown> =>
   typeof input === 'object' && input !== null && !Array.isArray(input)
 
+// Distinguishes a Promise (or any thenable) from a synchronous value, so the
+// commit engine can tell a synchronous `onUpdate` verdict from an async one
+// and resolve the sync case in place (no optimistic apply).
+export const isThenable = (value: unknown): value is PromiseLike<unknown> =>
+  value != null &&
+  (typeof value === 'object' || typeof value === 'function') &&
+  typeof (value as { then?: unknown }).then === 'function'
+
 export const isJsEvent = (value: unknown) => {
   return (
     value &&

--- a/test/JsonEditor.test.tsx
+++ b/test/JsonEditor.test.tsx
@@ -1198,14 +1198,15 @@ describe('JsonEditor — §17 onEditEvent lifecycle stream', () => {
     expect(onEditEvent.mock.calls.map(([e]) => e.event)).toEqual(['startAdd', 'cancelAdd'])
   })
 
-  test('add (object): a rejected confirm commits optimistically then reverts with updateError', async () => {
+  test('add (object): a SYNC rejected confirm closes the add without committing (cancelAdd, no write)', async () => {
     const user = userEvent.setup()
     const onEditEvent = jest.fn<void, [EditEvent]>()
+    const setData = jest.fn()
     const onUpdate = jest.fn(() => false as const)
     const { container } = render(
       <JsonEditor
         data={{ existing: 'value' }}
-        setData={noop}
+        setData={setData}
         onUpdate={onUpdate}
         onEditEvent={onEditEvent}
         showIconTooltips
@@ -1217,8 +1218,56 @@ describe('JsonEditor — §17 onEditEvent lifecycle stream', () => {
     await user.clear(newKeyInput)
     await user.type(newKeyInput, 'fresh{Enter}')
 
-    // Optimistic add (§ new model): the session commits (commitAdd), then the
-    // rejected settlement reverts the node and reports updateError.
+    // A synchronous reject is known before the optimistic apply, so the add
+    // never commits: the session closes (cancelAdd, not commitAdd) and
+    // updateError reports the rejection — `setData` is never called, so the new
+    // key never flashes into the document. (Contrast the async path below,
+    // which DOES commit optimistically then revert.)
+    await waitFor(() =>
+      expect(onEditEvent.mock.calls.map(([e]) => e.event)).toEqual([
+        'startAdd',
+        'submitAdd',
+        'cancelAdd',
+        'updateError',
+      ])
+    )
+    expect(setData).not.toHaveBeenCalled()
+  })
+
+  test('add (object): an ASYNC rejected confirm commits optimistically then reverts with updateError', async () => {
+    const user = userEvent.setup()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    const setData = jest.fn()
+    const deferred = makeDeferred<false>()
+    const onUpdate = jest.fn(() => deferred.promise)
+    const { container } = render(
+      <JsonEditor
+        data={{ existing: 'value' }}
+        setData={setData}
+        onUpdate={onUpdate}
+        onEditEvent={onEditEvent}
+        showIconTooltips
+      />
+    )
+
+    await user.click(screen.getByTitle('Add'))
+    const newKeyInput = container.querySelector('input.jer-input-new-key') as HTMLInputElement
+    await user.clear(newKeyInput)
+    await user.type(newKeyInput, 'fresh{Enter}')
+
+    // Async verdict can't be known in time, so the add applies optimistically
+    // (commitAdd) to keep the UI instant; the later rejection reverts it.
+    await waitFor(() =>
+      expect(onEditEvent.mock.calls.map(([e]) => e.event)).toEqual([
+        'startAdd',
+        'submitAdd',
+        'commitAdd',
+      ])
+    )
+    expect(setData).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      deferred.resolve(false)
+    })
     await waitFor(() =>
       expect(onEditEvent.mock.calls.map(([e]) => e.event)).toEqual([
         'startAdd',
@@ -1227,6 +1276,8 @@ describe('JsonEditor — §17 onEditEvent lifecycle stream', () => {
         'updateError',
       ])
     )
+    // Optimistic add then revert: two writes, netting back to the original.
+    expect(setData).toHaveBeenCalledTimes(2)
   })
 
   test('delete fires a single "delete" event', async () => {
@@ -1730,16 +1781,49 @@ describe('JsonEditor — restrictions and callbacks', () => {
 
     // onUpdate ran with the attempted new value
     expect(onUpdate).toHaveBeenCalledTimes(1)
-    // Optimistic model: the edit applies immediately, then the rejection
-    // reverts it — so the LAST write restores the original and external state
-    // nets out unchanged. (The per-commit token ensures a late rejection
-    // reverts only its own node, never clobbering a newer commit that landed
-    // while it was settling.)
-    expect(setData).toHaveBeenLastCalledWith({ x: 'hello' })
+    // A synchronous reject is known before the optimistic apply, so the engine
+    // skips the apply entirely — `setData` is never called (no optimistic
+    // write, no revert). The end-state is unchanged from the optimistic path,
+    // but nothing for a history/undo wrapper or autosave downstream of
+    // `setData` is left to record.
+    expect(setData).not.toHaveBeenCalled()
     // The node reverts its own display, and the default error shows.
     expect(screen.getByText('"hello"')).toBeInTheDocument()
     expect(screen.queryByText('"rejected"')).toBeNull()
     expect(screen.getByText('Update unsuccessful')).toBeInTheDocument()
+  })
+
+  test('a valid synchronous onUpdate commits once and reports updateSuccess', async () => {
+    const user = userEvent.setup()
+    const setData = jest.fn()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
+    const onUpdate = jest.fn(() => undefined) // approve
+    render(
+      <JsonEditor
+        data={{ x: 'hello' }}
+        setData={setData}
+        onUpdate={onUpdate}
+        onEditEvent={onEditEvent}
+      />
+    )
+
+    await user.dblClick(screen.getByText('"hello"'))
+    const input = screen.getByRole('textbox')
+    await user.clear(input)
+    await user.type(input, 'world{Enter}')
+
+    // The sync fast-path must still COMMIT a valid edit (no over-suppression):
+    // a single write, and the standard commitEdit → updateSuccess settlement.
+    await waitFor(() => expect(setData).toHaveBeenCalledWith({ x: 'world' }))
+    expect(setData).toHaveBeenCalledTimes(1)
+    await waitFor(() =>
+      expect(onEditEvent.mock.calls.map(([e]) => e.event)).toEqual([
+        'startEdit',
+        'submitEdit',
+        'commitEdit',
+        'updateSuccess',
+      ])
+    )
   })
 
   test('onUpdate returning false on a delete shows the delete-specific message', async () => {
@@ -1784,10 +1868,18 @@ describe('JsonEditor — restrictions and callbacks', () => {
 
   test('onUpdate returning false on a rename shows the rename-specific message and code', async () => {
     const user = userEvent.setup()
+    const setData = jest.fn()
+    const onEditEvent = jest.fn<void, [EditEvent]>()
     const onUpdate = jest.fn(() => false as const)
     const onError = jest.fn()
     render(
-      <JsonEditor data={{ oldName: 2 }} setData={noop} onUpdate={onUpdate} onError={onError} />
+      <JsonEditor
+        data={{ oldName: 2 }}
+        setData={setData}
+        onUpdate={onUpdate}
+        onError={onError}
+        onEditEvent={onEditEvent}
+      />
     )
 
     await user.dblClick(screen.getByText('oldName'))
@@ -1801,6 +1893,17 @@ describe('JsonEditor — restrictions and callbacks', () => {
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({ error: expect.objectContaining({ code: 'RENAME_ERROR' }) })
     )
+    // Synchronous reject: no optimistic apply, so the rename closes via
+    // cancelRename (not commitRename) and `setData` is never called.
+    await waitFor(() =>
+      expect(onEditEvent.mock.calls.map(([e]) => e.event)).toEqual([
+        'startRename',
+        'submitRename',
+        'cancelRename',
+        'updateError',
+      ])
+    )
+    expect(setData).not.toHaveBeenCalled()
   })
 
   // A rejected move would surface 'Move unsuccessful' (code MOVE_ERROR), but
@@ -1890,9 +1993,9 @@ describe('JsonEditor — restrictions and callbacks', () => {
     await user.type(input, 'rejected{Enter}')
 
     // An empty error string is a rejection, not a silent success: the
-    // optimistic apply is reverted (last write restores the original), the
-    // display reverts, and onError fires (with the empty message).
-    expect(setData).toHaveBeenLastCalledWith({ x: 'hello' })
+    // synchronous reject skips the optimistic apply (`setData` never called),
+    // the display reverts, and onError fires (with the empty message).
+    expect(setData).not.toHaveBeenCalled()
     expect(onError).toHaveBeenCalledWith(
       expect.objectContaining({
         error: expect.objectContaining({ code: 'UPDATE_ERROR', message: '' }),
@@ -2029,9 +2132,9 @@ describe('JsonEditor — restrictions and callbacks', () => {
     await user.type(input, 'discarded{Enter}')
 
     expect(onUpdate).toHaveBeenCalledTimes(1)
-    // Silent abort after an optimistic apply: the last write reverts to the
-    // original (net no change)...
-    expect(setData).toHaveBeenLastCalledWith({ x: 'hello' })
+    // Silent abort: a synchronous cancel is known before the optimistic apply,
+    // so the apply is skipped and `setData` is never called (net no change)...
+    expect(setData).not.toHaveBeenCalled()
     // ...no error message...
     expect(screen.queryByText('Update unsuccessful')).toBeNull()
     // ...and the input reverts to the original (not the typed-but-cancelled

--- a/test/imperativeHandle.test.tsx
+++ b/test/imperativeHandle.test.tsx
@@ -189,9 +189,10 @@ describe('editorRef handle — confirm / cancel', () => {
         error: expect.objectContaining({ code: 'UPDATE_ERROR', message: 'nope' }),
       })
     )
-    // Optimistic model: the value applies then the veto reverts it — the LAST
-    // write restores the original, so the edit nets out uncommitted.
-    expect(setData).toHaveBeenLastCalledWith({ greeting: 'hello' })
+    // Synchronous veto: the reject is known before the optimistic apply, so
+    // the apply is skipped and `setData` is never called — the edit nets out
+    // uncommitted with no transient write.
+    expect(setData).not.toHaveBeenCalled()
   })
 
   test('confirm() is a no-op with no value-edit control (does not cancel a key rename)', async () => {

--- a/test/useUndo.test.tsx
+++ b/test/useUndo.test.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react'
-import { act, renderHook } from '@testing-library/react'
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { JsonEditor } from '../src/JsonEditor'
+import { type JsonData, type UpdateFunction } from '../src/types'
 import { useUndo } from '../packages/utils/src'
 // Pure transitions are package-internal (not re-exported from the barrel), so
 // the queue-maths unit tests reach for them directly.
@@ -109,6 +112,55 @@ describe('useUndo — behaviour', () => {
     act(() => result.current.set((prev) => ({ v: prev.v + 1 })))
     expect(result.current.data).toEqual({ v: 6 })
     expect(result.current.canUndo).toBe(true)
+  })
+})
+
+// Drives a real editor through `useUndo` (as a consumer would: `set` is the
+// editor's `setData`), surfacing `canUndo` so the test can read the stack.
+const UndoEditor = ({ initial, onUpdate }: { initial: JsonData; onUpdate?: UpdateFunction }) => {
+  const [data, setData] = useState<JsonData>(initial)
+  const undo = useUndo<JsonData>(data, setData)
+  return (
+    <>
+      <span data-testid="can-undo">{String(undo.canUndo)}</span>
+      <JsonEditor<JsonData> data={undo.data} setData={undo.set} onUpdate={onUpdate} />
+    </>
+  )
+}
+
+describe('useUndo + JsonEditor (synchronous-reject integration)', () => {
+  it('a synchronously rejected edit leaves the undo stack clean', async () => {
+    const user = userEvent.setup()
+    // A synchronous validator that rejects the edit.
+    const onUpdate: UpdateFunction = () => false
+    render(<UndoEditor initial={{ x: 'hello' }} onUpdate={onUpdate} />)
+    expect(screen.getByTestId('can-undo')).toHaveTextContent('false')
+
+    await user.dblClick(screen.getByText('"hello"'))
+    const input = screen.getByRole('textbox')
+    await user.clear(input)
+    await user.type(input, 'rejected{Enter}')
+
+    await waitFor(() => expect(screen.getByText('Update unsuccessful')).toBeInTheDocument())
+    // The reject never wrote through `set`, so there is no snapshot to undo —
+    // no phantom step that would step back to the rejected value (the original
+    // #issue this fix addresses).
+    expect(screen.getByTestId('can-undo')).toHaveTextContent('false')
+    expect(screen.getByText('"hello"')).toBeInTheDocument()
+  })
+
+  it('a valid edit records exactly one undoable step', async () => {
+    const user = userEvent.setup()
+    render(<UndoEditor initial={{ x: 'hello' }} />)
+    expect(screen.getByTestId('can-undo')).toHaveTextContent('false')
+
+    await user.dblClick(screen.getByText('"hello"'))
+    const input = screen.getByRole('textbox')
+    await user.clear(input)
+    await user.type(input, 'world{Enter}')
+
+    await waitFor(() => expect(screen.getByText('"world"')).toBeInTheDocument())
+    expect(screen.getByTestId('can-undo')).toHaveTextContent('true')
   })
 })
 


### PR DESCRIPTION
## Problem

In the v2 optimistic editing model, an editor-op commit (value **edit** / key **rename** / **add-to-object**) called `apply()` *synchronously* — before the consumer's `onUpdate` verdict was known — then `revert()`d if `onUpdate` rejected. Both writes go through `setData`, so a **rejected** edit produced **two** `setData` calls (apply + revert) for a value that was never accepted.

This pollutes anything downstream of `setData`. It surfaced via `@json-edit-react/utils`' `useUndo`: a synchronously rejected edit wrote a bogus snapshot into the undo stack, so "Undo" stepped back to the illegal value.

The engine already avoided this for *instant* ops (delete / move / array-add) via their ~100ms settle delay — but editor ops opted out because a delay on the editor *close* would be perceptible. Sync-ness, however, is directly detectable: when `onUpdate` returns a non-thenable, the verdict is known in the same tick, so there's no need to apply optimistically at all.

## Change

- **`runUpdate` is now sync-or-async** ([src/JsonEditor.tsx](../blob/main/src/JsonEditor.tsx)): it calls `onUpdate` directly (extracted `normalise`/`toError` helpers) and returns the outcome **synchronously** unless `onUpdate` is genuinely async. Return type widened to `UpdateOutcome | Promise<UpdateOutcome>`.
- **`submit()` sync fast-path** ([src/contexts/EditingProvider.tsx](../blob/main/src/contexts/EditingProvider.tsx)): on a synchronous editor-op verdict, skip the optimistic `apply()` and hand the outcome straight to `reconcile` — whose existing `!applied()` branch already applies for commit/override and stays put for error/cancel.
- **`reconcile()`** widened its pre-apply close condition to also close a non-held `'editing'` session, so a sync reject closes + reverts exactly as before.
- Added an `isThenable` helper in [src/utils/misc.ts](../blob/main/src/utils/misc.ts).

Instant, held, and async paths are unchanged.

## Behaviour

For **synchronous** `onUpdate` rejects of editor ops:
- `setData` is **not** called (was: apply + revert) → clean `useUndo` history, no autosave/dirty-flag flicker, no value-flash.
- Events: `submit* → cancel* → updateError` (was `commit* → updateError`), matching how instant ops already report sync rejects.
- Inline error still shows; editor closes; value reverts — **end-state identical to before**.

**Unchanged:** valid commits (one `setData` + `updateSuccess`); all **async** rejects (still optimistic apply-then-revert); instant ops; `hold()` / confirm flows.

## Tests & docs

- Updated the existing sync-reject tests to the new contract (`JsonEditor.test.tsx`, `imperativeHandle.test.tsx`).
- Added regression coverage: sync edit/object-add/rename rejects (no write, `cancel*`), a valid sync commit, an async-add optimistic-then-revert guard, and an **end-to-end `useUndo` test** (sync-rejected edit leaves the undo stack clean).
- **687 tests pass; `pnpm compile` and `pnpm lint` clean.**
- README: reframed the optimistic-model section around the sync/async split, clarified `data`/`setData` (local state) vs `onUpdate` (external writes), updated the lifecycle note.

## Follow-up (not in this PR)

Async-validation clean history via an `onEditEvent`-gated `useUndo` is the remaining piece — async rejects still write apply-then-revert; consumers wanting clean history under *async* validation use `hold()` today. Deliberately scoped out; `useUndo` is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)