### PR TITLE
Add `AutoType` custom component

### DIFF
--- a/demo/src/examples/registry.ts
+++ b/demo/src/examples/registry.ts
@@ -111,6 +111,14 @@ const allExamples: Record<string, ExampleDef> = {
     load: () => import('./static/type-restrictions/Example'),
     code: () => import('./static/type-restrictions/Example.tsx?raw'),
   },
+  'auto-type': {
+    kind: 'static',
+    title: 'Auto-type',
+    blurb:
+      'Drop the Type selector entirely: the `AutoType` component (from `@json-edit-react/components`) edits every value through one plain text input and infers the type from what you type — `12.3` → number, `true` → boolean, `{…}` / `[…]` → object / array, and anything else a string. Type an object literal into a leaf to grow a whole collection. Here the text is read with JSON5 (via the component\'s `jsonParse` prop), so unquoted keys, single quotes and trailing commas all work. Anything that isn\'t valid JSON5 stays a string — including `"0077"`, whose leading zeros aren\'t valid number syntax. Paired with `allowTypeSelection={false}`.',
+    load: () => import('./static/auto-type/Example'),
+    code: () => import('./static/auto-type/Example.tsx?raw'),
+  },
   enums: {
     kind: 'static',
     title: 'Enums',

--- a/demo/src/examples/static/auto-type/Example.tsx
+++ b/demo/src/examples/static/auto-type/Example.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+import JSON5 from 'json5'
+import { JsonEditor, type JsonData } from '@json-edit-react'
+import { autoTypeDefinition } from '@json-edit-react/components'
+import { useEditorDefaults } from '@example-resources'
+
+// Every value is edited through a single text input — there's
+// no Type selector. What you type decides the type, parsed
+// with JSON5 (so unquoted keys, single quotes and trailing
+// commas are all fine):
+//
+//   hello       → string
+//   12.3        → number
+//   true        → boolean
+//   null        → null
+//   {a: 1}      → object   (a leaf grows into a collection!)
+//   [1, 2, 3,]  → array
+//
+// Anything that doesn't parse stays a string — "0077"
+// included: leading zeros aren't valid number syntax, so the
+// serial number stays text rather than turning into 77.
+// Collections aren't matched, so they keep the built-in
+// "Edit as JSON" editor (also JSON5 here); edit one down to a
+// bare value and it becomes that primitive.
+const initialData = {
+  spacecraft: 'Voyager 1',
+  launchYear: 1977,
+  operational: true,
+  distanceFromSunAU: 165.2,
+  serialNumber: '0077', // looks numeric, but stays a string
+  returnCrew: null,
+  instruments: ['magnetometer', 'cosmic-ray detector', 'plasma-wave sensor'],
+  power: {
+    isotope: 'plutonium-238',
+    outputWatts: 249,
+    annualDecayPercent: 0.78,
+    redundant: true,
+  },
+  trajectory: {
+    velocityKmPerSec: 17,
+    headingTowards: 'Ophiuchus',
+    interstellar: true,
+  },
+  recentLog: [
+    { date: '2012-08-25', event: 'crossed the heliopause' },
+    { date: '2025-05-12', event: 'routine telemetry ping' },
+  ],
+  goldenRecord: {
+    greetingLanguages: 55,
+    includesEarthSounds: true,
+    playbackInstructions: 'etched on the cover',
+  },
+}
+
+// `autoTypeDefinition()` guards itself to value nodes and
+// applies everywhere; `allowTypeSelection={false}` drops the
+// now-redundant Type selector. `componentProps.jsonParse`
+// makes the inline editor read relaxed JSON5; the matching
+// editor-level `jsonParse` does the same for the collection
+// "Edit as JSON" editor.
+const customNodeDefinitions = [autoTypeDefinition({ componentProps: { jsonParse: JSON5.parse } })]
+
+export default function AutoType() {
+  const [data, setData] = useState<JsonData>(initialData)
+
+  return (
+    <JsonEditor
+      data={data}
+      setData={setData}
+      {...useEditorDefaults()}
+      rootName="probe"
+      allowTypeSelection={false}
+      jsonParse={JSON5.parse}
+      customNodeDefinitions={customNodeDefinitions}
+    />
+  )
+}

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.9.0-beta.4
 
+### Minor Changes
+
+- New `AutoType` component (#393): an edit-only node that replaces the Type selector with a single text input and infers the value's type from what you type — `12.3` → number, `true` → boolean, `null` → null, `{…}`/`[…]` → object/array, and anything else a string. It applies to every value node (pair it with `allowTypeSelection={false}`); collections aren't matched, so they keep their built-in "Edit as JSON" editor. Confirming an unchanged value keeps the original, so a string that merely looks like a number won't silently re-type. Accepts an optional `jsonParse` component prop (default `JSON.parse`) for a lenient parser such as `JSON5.parse`.
+
 ### Patch Changes
 
 - ColorPicker: fix an occasional infinite re-render / feedback loop between the picker and the text input (#390). The picker's own output is now echoed straight back into react-colorful's `color` prop instead of being re-derived through colord: that round-trip re-rounded the value and re-added the alpha key the non-alpha picker strips, defeating react-colorful's `===` identity check and forcing a redundant re-sync on every change (and collapsing the hue at the grey axis). A finiteness guard also ensures react-colorful never receives a non-finite colour — a `NaN` (which its pointer math can produce for a zero-size picker) would otherwise permanently defeat that same identity check and spin an infinite render. colord is still used to format the text value, and the ineffective `isUpdatingFromPicker` guard is removed.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -282,6 +282,8 @@ It guards to value (leaf) nodes, so a `condition` that also matches a collection
 
 An edit-only node that replaces the Type selector with a single plain text input and infers the value's type from what you type. `12.3` becomes a number, `true`/`false` a boolean, `null` the null value, `{"a":1}` or `[1,2,3]` an object or array, and anything that doesn't parse stays a string. It applies to every value (non-collection) node.
 
+[![▶ Live example: Auto-type](https://img.shields.io/badge/▶_Live_example-Auto--type-2ea44f?style=for-the-badge)](https://carlosnz.github.io/json-edit-react-v2/examples/auto-type)
+
 ```tsx
 autoTypeDefinition()
 ```

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -39,6 +39,7 @@ Each component ships a React component plus a definition factory that produces a
 | `Symbol`         | `Symbol` value display ([details](#symbol--javascript-symbols))                                                                                                   | —                                          |
 | `Undefined`      | `undefined` value display ([details](#undefined--the-undefined-value))                                                                                            | —                                          |
 | `ErrorIndicator` | Wraps a node with a glyph (default ⚠️) to flag the nodes you target via `condition` — e.g. validation errors ([details](#errorindicator--flag-nodes-with-a-glyph)) | —                                          |
+| `AutoType`       | Edit-only text input on every value node that infers the type from what you type — `12.3` → number, `true` → boolean, `{…}`/`[…]` → object/array, otherwise a string ([details](#autotype--type-follows-the-input)) | —                                          |
 
 ### Editor slot widgets
 
@@ -276,6 +277,26 @@ const customNodeDefinitions = useMemo(
 Memoizing on `validation` re-renders the tree exactly when validity changes, so the marker appears/clears correctly even when an edit on one node flips the validity of a node on another branch. Options, via `componentProps`: `errorGlyph` (any `ReactNode`, default `⚠️`) and `position` (`'before' | 'after'`, default `'after'`). With no `condition` it flags nothing (its default targeting is a deliberate no-op).
 
 It guards to value (leaf) nodes, so a `condition` that also matches a collection (e.g. an AJV `if`/`then` error reported at a parent object's path) never decorates that collection — only the leaf where the value is wrong. For collection-level marking, tint the subtree with `validationStyles({ within })` from `@json-edit-react/utils` instead.
+
+### `AutoType` — type follows the input
+
+An edit-only node that replaces the Type selector with a single plain text input and infers the value's type from what you type. `12.3` becomes a number, `true`/`false` a boolean, `null` the null value, `{"a":1}` or `[1,2,3]` an object or array, and anything that doesn't parse stays a string. It applies to every value (non-collection) node.
+
+```tsx
+autoTypeDefinition()
+```
+
+Pair it with `allowTypeSelection={false}` on the editor: the typed text already chooses the type, so the dropdown is redundant.
+
+The text is read with `JSON.parse` by default. Pass a more lenient parser via `componentProps.jsonParse` — for example [`JSON5`](https://json5.org)'s `parse`, the same function you'd give `<JsonEditor jsonParse={…} />` — to accept unquoted keys, single quotes and trailing commas:
+
+```tsx
+autoTypeDefinition({ componentProps: { jsonParse: JSON5.parse } })
+```
+
+A string that merely *looks* like another type (the string `"12.3"`) is shown without quotes, but it only re-types if you actually change it — opening and confirming an untouched value leaves it exactly as it was, so a stringy number won't silently become a real one. The one thing auto-typing can't round-trip is a string whose content is itself quoted (`"\"quoted\""`): editing it parses the quotes away. Collections aren't matched — they keep their built-in "Edit as JSON" editor — so the conversion still works both ways: type `{…}` into a leaf to grow a collection, or edit a collection's JSON down to a primitive.
+
+**Saving to JSON:** every value it produces is already standard JSON, so there's nothing special to serialise.
 
 ## Tree-shaking
 

--- a/packages/components/src/AutoType/component.tsx
+++ b/packages/components/src/AutoType/component.tsx
@@ -1,0 +1,39 @@
+import { type Dispatch, type SetStateAction } from 'react'
+import { StringEdit, toPathString, type CustomComponentProps, type JsonData } from 'json-edit-react'
+
+export interface AutoTypeProps {
+  /**
+   * Parser used to infer the type from the typed text. Defaults to
+   * `JSON.parse`; pass a more lenient parser (e.g. `JSON5.parse`) to accept
+   * unquoted keys, single quotes, trailing commas, etc. Mirrors core's
+   * `jsonParse` signature, so the same function passed to
+   * `<JsonEditor jsonParse={…}>` works here too.
+   */
+  jsonParse?: (input: string, reviver?: (key: string, value: string) => unknown) => JsonData
+}
+
+// Edit-only node (the definition sets `showOnView: false`), so this is only
+// ever rendered while editing — the body is just a plain text input. The
+// value's type is decided from the text on commit, in the definition's
+// `fromStandardType`.
+export const AutoTypeComponent = (props: CustomComponentProps<AutoTypeProps>) => {
+  const { value, setValue, getStyles, nodeData, handleEdit, ...rest } = props
+
+  // The buffer holds the committed value verbatim until the first keystroke
+  // (StringEdit only writes on input), so stringify non-strings for display.
+  // The definition guards to non-collection nodes, so `value` here is only
+  // ever a primitive — `String` matches what a JSON parser round-trips
+  // (12.3 → "12.3", true → "true", null → "null").
+  const text = typeof value === 'string' ? value : String(value)
+
+  return (
+    <StringEdit
+      pathString={toPathString(nodeData.path)}
+      styles={getStyles('input', nodeData)}
+      {...rest}
+      value={text}
+      setValue={setValue as Dispatch<SetStateAction<string>>}
+      handleEdit={handleEdit}
+    />
+  )
+}

--- a/packages/components/src/AutoType/definition.ts
+++ b/packages/components/src/AutoType/definition.ts
@@ -1,0 +1,38 @@
+import { isCollection, type CustomNodeDefinition } from 'json-edit-react'
+import { createDefinitionFactory } from '../_common/createDefinitionFactory'
+import { AutoTypeComponent, type AutoTypeProps } from './component'
+
+// An edit-only node that infers a value's type from the text typed into a
+// plain input — no Type selector. The text is parsed (JSON by default), so
+// "12.3" → number, "true" → boolean, "null" → null, '{"a":1}' → object/array,
+// and anything that doesn't parse stays a string. Applies to every value
+// (non-collection) node; collections keep their built-in "Edit as JSON"
+// editor, through which a primitive can still be typed in.
+//
+// The `condition` doubles as the guard (value nodes only): a consumer
+// `condition` override is treated as targeting and ANDed with this by the
+// factory, so it can only narrow WHERE auto-typing applies.
+const AutoTypeDefinition: CustomNodeDefinition<AutoTypeProps> = {
+  condition: ({ value }) => !isCollection(value),
+  component: AutoTypeComponent,
+  showOnView: false, // edit-only — the standard node renders in view mode
+  showOnEdit: true,
+  showInTypeSelector: false,
+  fromStandardType: (value, nodeData, componentProps) => {
+    const parse = componentProps?.jsonParse ?? JSON.parse
+    // `value` is the edit buffer; until the user types it's the committed
+    // value verbatim, and `nodeData.value` is the committed value (stable for
+    // the session). So an unchanged confirm keeps the original untouched — a
+    // string that merely looks like another type ("12.3", "true") doesn't
+    // silently flip when the editor is opened and closed without an edit.
+    if (typeof value !== 'string') return value
+    if (value === nodeData.value) return value
+    try {
+      return parse(value)
+    } catch {
+      return value
+    }
+  },
+}
+
+export const autoTypeDefinition = createDefinitionFactory(AutoTypeDefinition)

--- a/packages/components/src/AutoType/index.ts
+++ b/packages/components/src/AutoType/index.ts
@@ -1,0 +1,2 @@
+export * from './definition'
+export * from './component'

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -12,6 +12,7 @@ export * from './Markdown'
 export * from './Image'
 export * from './ColorPicker'
 export * from './ErrorIndicator'
+export * from './AutoType'
 
 // The definition factories' override surface; the factory builder itself
 // (`createDefinitionFactory`) stays internal

--- a/packages/components/test/AutoType.test.tsx
+++ b/packages/components/test/AutoType.test.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { JsonEditor, type CustomNodeDefinition, type JsonData } from 'json-edit-react'
+import { autoTypeDefinition } from '../src/AutoType'
+
+// Stateful harness so a committed value re-enters via `data` — required for a
+// leaf → collection commit, where the node has to re-route to a CollectionNode
+// once its value becomes an object/array.
+const Harness = ({
+  initial,
+  onData,
+  defs = [autoTypeDefinition()],
+}: {
+  initial: JsonData
+  onData: (d: JsonData) => void
+  // Mirrors core's `customNodeDefinitions` prop type (permissive `any`
+  // componentProps), so a typed `CustomNodeDefinition<AutoTypeProps>` assigns.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defs?: CustomNodeDefinition<Record<string, any>>[]
+}) => {
+  const [data, setData] = useState<JsonData>(initial)
+  return (
+    <JsonEditor
+      data={data}
+      setData={(d) => {
+        onData(d)
+        setData(d)
+      }}
+      customNodeDefinitions={defs}
+      // The component is meant to be paired with the type selector turned off:
+      // the typed text picks the type, so the dropdown is redundant.
+      allowTypeSelection={false}
+    />
+  )
+}
+
+const openEditor = async (user: ReturnType<typeof userEvent.setup>, displayText: string) => {
+  await user.dblClick(screen.getByText(displayText))
+  return screen.getByRole('textbox') as HTMLTextAreaElement
+}
+
+// `fireEvent.change` rather than `user.type`: the buffer often contains `{`,
+// `[` and `"`, which user.type interprets as special key syntax.
+const setBuffer = (input: HTMLTextAreaElement, text: string) =>
+  fireEvent.change(input, { target: { value: text } })
+
+const confirm = (user: ReturnType<typeof userEvent.setup>, container: HTMLElement) =>
+  user.click(container.querySelectorAll('.jer-confirm-buttons > button')[0])
+
+describe('AutoType — type inference from typed text', () => {
+  test.each([
+    ['12.3', 12.3],
+    ['42', 42],
+    ['-7', -7],
+    ['true', true],
+    ['false', false],
+    ['null', null],
+  ])('typing %p commits the parsed value %p', async (typed, expected) => {
+    const user = userEvent.setup()
+    const onData = jest.fn()
+    const { container } = render(<Harness initial={{ x: 'start' }} onData={onData} />)
+
+    const input = await openEditor(user, '"start"')
+    setBuffer(input, typed)
+    await confirm(user, container)
+
+    expect(onData).toHaveBeenCalledWith({ x: expected })
+  })
+
+  test('text that does not parse stays a string', async () => {
+    const user = userEvent.setup()
+    const onData = jest.fn()
+    const { container } = render(<Harness initial={{ x: 'start' }} onData={onData} />)
+
+    const input = await openEditor(user, '"start"')
+    setBuffer(input, 'hello world')
+    await confirm(user, container)
+
+    expect(onData).toHaveBeenCalledWith({ x: 'hello world' })
+  })
+
+  test('typing an object literal turns a leaf into an object (leaf → collection)', async () => {
+    const user = userEvent.setup()
+    const onData = jest.fn()
+    const { container } = render(<Harness initial={{ x: 1 }} onData={onData} />)
+
+    const input = await openEditor(user, '1')
+    setBuffer(input, '{"a":1,"b":2}')
+    await confirm(user, container)
+
+    expect(onData).toHaveBeenCalledWith({ x: { a: 1, b: 2 } })
+    // The committed object re-enters and mounts as a real collection.
+    await waitFor(() => expect(screen.getByText('a')).toBeInTheDocument())
+    expect(screen.getByText('b')).toBeInTheDocument()
+  })
+
+  test('typing an array literal turns a leaf into an array', async () => {
+    const user = userEvent.setup()
+    const onData = jest.fn()
+    const { container } = render(<Harness initial={{ x: 'start' }} onData={onData} />)
+
+    const input = await openEditor(user, '"start"')
+    setBuffer(input, '[1,2,3]')
+    await confirm(user, container)
+
+    expect(onData).toHaveBeenCalledWith({ x: [1, 2, 3] })
+  })
+})
+
+describe('AutoType — round-trip stability', () => {
+  test('an unchanged string that looks like a number stays a string', async () => {
+    const user = userEvent.setup()
+    const onData = jest.fn()
+    const { container } = render(<Harness initial={{ x: '12.3' }} onData={onData} />)
+
+    // Open and confirm without touching the text.
+    await openEditor(user, '"12.3"')
+    await confirm(user, container)
+
+    // It must not flip to the number 12.3 — and the quotes in the view confirm
+    // it's still a string.
+    expect(onData).not.toHaveBeenCalledWith({ x: 12.3 })
+    expect(screen.getByText('"12.3"')).toBeInTheDocument()
+  })
+
+  test('actually editing a stringy-number re-parses it', async () => {
+    const user = userEvent.setup()
+    const onData = jest.fn()
+    const { container } = render(<Harness initial={{ x: '5' }} onData={onData} />)
+
+    const input = await openEditor(user, '"5"')
+    setBuffer(input, '99')
+    await confirm(user, container)
+
+    expect(onData).toHaveBeenCalledWith({ x: 99 })
+  })
+})
+
+describe('AutoType — custom parser', () => {
+  test('componentProps.jsonParse overrides the default JSON.parse', async () => {
+    const user = userEvent.setup()
+    const onData = jest.fn()
+    // A sentinel parser proves the configured parser is the one used.
+    const jsonParse = jest.fn(() => ({ parsed: 'custom' }))
+    const { container } = render(
+      <Harness
+        initial={{ x: 'start' }}
+        onData={onData}
+        defs={[autoTypeDefinition({ componentProps: { jsonParse } })]}
+      />
+    )
+
+    const input = await openEditor(user, '"start"')
+    setBuffer(input, 'anything')
+    await confirm(user, container)
+
+    expect(jsonParse).toHaveBeenCalledWith('anything')
+    expect(onData).toHaveBeenCalledWith({ x: { parsed: 'custom' } })
+  })
+})


### PR DESCRIPTION
Closes #393.

A new **`AutoType`** component for `@json-edit-react/components`: an edit-only node that replaces the Type selector with a single plain text input and infers the value's type from what you type.

- `12.3` → number, `true`/`false` → boolean, `null` → null, `{"a":1}` → object, `[1,2,3]` → array, and anything that doesn't parse stays a string.
- Applies to **every value node** (guard `({ value }) => !isCollection(value)`); collections aren't matched, so they keep their built-in "Edit as JSON" editor. The leaf→collection direction works too — type an object literal into a leaf and it grows into a real collection.
- No type selector by design — pair it with `allowTypeSelection={false}`.

### How it works

The type detection lives in the definition's `fromStandardType` (`componentProps?.jsonParse ?? JSON.parse`), so every confirm path (Enter / ✓ / Tab) funnels through one transform — the established pattern for the shipped components. The component itself is ~10 lines: a `StringEdit` over the value.

An **unchanged confirm keeps the original value** via a `value === nodeData.value` check: the edit buffer holds the committed value verbatim until the first keystroke, and `nodeData.value` is the committed value, so opening and confirming a stringy value without editing it never silently re-types it. (A `"0077"`-style string stays a string regardless, since leading zeros aren't valid number syntax.)

Optional `jsonParse` component prop (default `JSON.parse`) accepts a lenient parser such as `JSON5.parse` for unquoted keys, single quotes and trailing commas. `jsonStringify` was deliberately *not* added — guarded to leaf nodes, the component only ever serialises primitives, where `String()` matches any JSON serializer.

### Included

- Component + definition + barrel export.
- **Regression test** (`packages/components/test/AutoType.test.tsx`, 12 cases): parse table, string fallback, **leaf → collection**, leaf → array, unchanged-revert, and the custom `jsonParse` override.
- README "Available components" row + details section, and a CHANGELOG entry under the pending `0.9.0-beta.4`.
- A JSON5-powered demo example at `/examples/auto-type`.

### Verification

- `pnpm --filter @json-edit-react/components compile` ✅, `build` ✅ (tree-shake check still passes — `hyperlinkDefinition` → 1.2 kB, no heavy deps pulled).
- Full Jest suite: **30 suites, 712 passed**, no regressions.
- Demo `tsc -b` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
