### PR TITLE
NumberFormatter component (#355)

### DIFF
--- a/demo/src/demoData/dataDefinitions.tsx
+++ b/demo/src/demoData/dataDefinitions.tsx
@@ -423,6 +423,7 @@ export const demoDataDefinitions: Record<string, DemoData> = {
       return {
         data: m.initialData,
         customNodeDefinitions: m.customNodeDefinitions,
+        allowTypeSelection: m.allowTypeSelection,
         customTextEditorAvailable: true,
       }
     },

--- a/demo/src/examples/static/custom-component-library/Example.tsx
+++ b/demo/src/examples/static/custom-component-library/Example.tsx
@@ -1,5 +1,10 @@
 import { useState } from 'react'
-import { JsonEditor, type JsonData } from '@json-edit-react'
+import {
+  JsonEditor,
+  type JsonData,
+  type EnumDefinition,
+  type TypeFilterFunction,
+} from '@json-edit-react'
 import {
   dateObjectDefinition,
   datePickerDefinition,
@@ -14,8 +19,10 @@ import {
   bigIntDefinition,
   colorPickerDefinition,
   markdownDefinition,
+  numberFormatterDefinition,
 } from '@json-edit-react/components'
 import { ReactDatePicker } from '@json-edit-react/components/widgets'
+import { byKey } from '@json-edit-react/utils/filters'
 import { initialData, type CustomComponentLibraryData } from './data'
 import { SearchBox, useEditorDefaults } from '@example-resources'
 
@@ -24,10 +31,60 @@ import { SearchBox, useEditorDefaults } from '@example-resources'
 // `CustomNodeDefinition`s for common data types and useful
 // data structures, wired onto a single data set. Hyperlinks,
 // an "enhanced" link, date/time editors, a UNIX-timestamp
-// editor, Markdown, an image, a colour picker, and the
-// non-JSON types (`undefined`, `NaN`, `Symbol`, `BigInt`).
+// editor, Markdown, an image, a colour picker, the
+// non-JSON types (`undefined`, `NaN`, `Symbol`, `BigInt`),
+// and locale-aware number formatting.
 
 export { initialData, type CustomComponentLibraryData }
+
+// The "Number Formatting" block's `locale` node is locked
+// to this enum. Picking a locale re-derives the
+// definitions below (they read it from the data), so every
+// number in the block reformats live.
+const localeEnum: EnumDefinition = {
+  enum: 'Locale',
+  values: [
+    'en-US',
+    'en-GB',
+    'de-DE',
+    'fr-FR',
+    'es-ES',
+    'it-IT',
+    'ja-JP',
+    'zh-CN',
+    'hi-IN',
+    'ar-EG',
+    'ru-RU',
+    'pt-BR',
+  ],
+  // Recognise the stored string as this enum on load (the
+  // node is locked to it, so it can't be switched to).
+  matchPriority: 1,
+}
+
+// A representative currency per locale, so the `currency`
+// demo also shows currency-specific rules (e.g. JPY has no
+// decimal places).
+const localeCurrency: Record<string, string> = {
+  'en-US': 'USD',
+  'en-GB': 'GBP',
+  'de-DE': 'EUR',
+  'fr-FR': 'EUR',
+  'es-ES': 'EUR',
+  'it-IT': 'EUR',
+  'ja-JP': 'JPY',
+  'zh-CN': 'CNY',
+  'hi-IN': 'INR',
+  'ar-EG': 'EGP',
+  'ru-RU': 'RUB',
+  'pt-BR': 'BRL',
+}
+
+// Lock `locale` to the enum dropdown; every other node
+// keeps the standard type selector (`true` = all types,
+// including the custom ones like BigInt/Symbol).
+export const allowTypeSelection: TypeFilterFunction = (node) =>
+  byKey('locale')(node) ? [localeEnum] : true
 
 // Some definitions are configured by values in the data set
 // itself (the "Image properties" and "Show Time in Date?"
@@ -35,6 +92,8 @@ export { initialData, type CustomComponentLibraryData }
 // rebuilt as it's edited.
 export const customNodeDefinitions = (currentData: JsonData) => {
   const libraryData = currentData as CustomComponentLibraryData
+  const locale = libraryData?.['Number Formatting']?.locale ?? 'en-US'
+  const currency = localeCurrency[locale] ?? 'USD'
   return [
     dateObjectDefinition({
       componentProps: {
@@ -74,13 +133,44 @@ export const customNodeDefinitions = (currentData: JsonData) => {
     symbolDefinition(),
     bigIntDefinition(),
     colorPickerDefinition(),
+    // "Number Formatting": one NumberFormatter per field,
+    // all sharing the `locale` picked above. It's
+    // display-only, so editing any of them shows the raw
+    // number (e.g. `rounded` is stored as 1.3333333).
+    numberFormatterDefinition({
+      condition: byKey('millions'),
+      componentProps: { locale },
+    }),
+    numberFormatterDefinition({
+      condition: byKey('currency'),
+      componentProps: { locale, options: { style: 'currency', currency } },
+    }),
+    numberFormatterDefinition({
+      condition: byKey('percent'),
+      componentProps: {
+        locale,
+        options: { style: 'percent', maximumFractionDigits: 2 },
+      },
+    }),
+    numberFormatterDefinition({
+      condition: byKey('units'),
+      componentProps: { locale, options: { style: 'unit', unit: 'kilometer' } },
+    }),
+    numberFormatterDefinition({
+      condition: byKey('compact'),
+      componentProps: { locale, options: { notation: 'compact' } },
+    }),
+    numberFormatterDefinition({
+      condition: byKey('rounded'),
+      componentProps: { locale, options: { maximumFractionDigits: 2 } },
+    }),
     // The factory ANDs these conditions with the built-in
     // string guard, so a node switched to another type
     // (e.g. number) renders natively rather than as
     // markdown text
-    markdownDefinition({ condition: ({ key }) => key === 'Markdown' }),
+    markdownDefinition({ condition: byKey('Markdown') }),
     markdownDefinition({
-      condition: ({ key }) => key === 'Intro',
+      condition: byKey('Intro'),
       showKey: false,
       componentProps: {
         components: {
@@ -106,6 +196,7 @@ export default function CustomComponentLibrary() {
         rootName="components"
         collapse={3}
         customNodeDefinitions={customNodeDefinitions(data)}
+        allowTypeSelection={allowTypeSelection}
         searchText={searchText}
       />
     </div>

--- a/demo/src/examples/static/custom-component-library/data.ts
+++ b/demo/src/examples/static/custom-component-library/data.ts
@@ -13,6 +13,7 @@ export const initialData = {
   - DatePicker
   - DateObject
   - UNIX Timestamp
+  - NumberFormatter
   - Undefined
   - Markdown
   - BigInt
@@ -42,6 +43,18 @@ export const initialData = {
     'Unix Timestamp (ms)': Date.now(),
     'Show Unix as raw number?': true,
     // info: 'Inserted in App.tsx',
+  },
+
+  'Number Formatting': {
+    locale: 'en-US',
+    millions: 1234989,
+    currency: 1789.89,
+    percent: 0.8756,
+    units: 2789.88,
+    compact: 1200000,
+    // Stored at full precision — NumberFormatter only
+    // rounds the *display* (to 1.33).
+    rounded: 1.3333333,
   },
 
   'Non-JSON types': {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @json-edit-react/components
 
+## 0.9.0-beta.5
+
+### Minor Changes
+
+- New `NumberFormatter` component (#355): a display-only node that formats number values via `Intl.NumberFormat` (thousands separators, currency, percent, …), edited as the raw number. Zero dependencies. See the README for usage.
+
 ## 0.9.0-beta.4
 
 ### Minor Changes

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -40,6 +40,7 @@ Each component ships a React component plus a definition factory that produces a
 | `Undefined`      | `undefined` value display ([details](#undefined--the-undefined-value))                                                                                            | —                                          |
 | `ErrorIndicator` | Wraps a node with a glyph (default ⚠️) to flag the nodes you target via `condition` — e.g. validation errors ([details](#errorindicator--flag-nodes-with-a-glyph)) | —                                          |
 | `AutoType`       | Edit-only text input on every value node that infers the type from what you type — `12.3` → number, `true` → boolean, `{…}`/`[…]` → object/array, otherwise a string ([details](#autotype--type-follows-the-input)) | —                                          |
+| `NumberFormatter` | Numbers formatted via `Intl.NumberFormat` (thousands separators, currency, percent, …), edited as the raw number ([details](#numberformatter--locale-aware-number-formatting)) | —                                          |
 
 ### Editor slot widgets
 
@@ -299,6 +300,43 @@ autoTypeDefinition({ componentProps: { jsonParse: JSON5.parse } })
 A string that merely *looks* like another type (the string `"12.3"`) is shown without quotes, but it only re-types if you actually change it — opening and confirming an untouched value leaves it exactly as it was, so a stringy number won't silently become a real one. The one thing auto-typing can't round-trip is a string whose content is itself quoted (`"\"quoted\""`): editing it parses the quotes away. Collections aren't matched — they keep their built-in "Edit as JSON" editor — so the conversion still works both ways: type `{…}` into a leaf to grow a collection, or edit a collection's JSON down to a primitive.
 
 **Saving to JSON:** every value it produces is already standard JSON, so there's nothing special to serialise.
+
+### `NumberFormatter` — locale-aware number formatting
+
+`NumberFormatter` renders number values through [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) — thousands separators, currency, percent, compact and scientific notation, units, sign display, and rounding — while leaving the stored value untouched. It's display-only: double-clicking (or the usual edit affordance) drops back to the node's ordinary number editor, so the raw, unformatted number is always what you edit. Zero dependencies, since `Intl` is built into the platform.
+
+Pass `Intl.NumberFormat` options through `componentProps.options`, and an optional BCP-47 `componentProps.locale` (omit it to use the runtime's locale):
+
+```jsx
+import { numberFormatterDefinition } from '@json-edit-react/components'
+
+// Currency
+numberFormatterDefinition({
+  componentProps: {
+    locale: 'en-US',
+    options: { style: 'currency', currency: 'USD' },
+  },
+})
+
+// Percent — a stored 0.5 displays as "50%"
+numberFormatterDefinition({
+  componentProps: { options: { style: 'percent' } },
+})
+```
+
+The guard matches **every** number and the default targeting is "everywhere the guard passes", so dropping the definition in unchanged reformats every number in the tree — years, IDs and ports included. That's rarely what you want, so narrow it with a `condition` (ANDed with the guard) that targets the fields you mean:
+
+```jsx
+import { numberFormatterDefinition } from '@json-edit-react/components'
+import { byKey } from '@json-edit-react/utils'
+
+numberFormatterDefinition({
+  condition: byKey(/price|amount|total|cost/i),
+  componentProps: { options: { style: 'currency', currency: 'USD' } },
+})
+```
+
+Because it's display-only, the value your data holds never changes: a `percent` style shows `0.5` as "50%" and a `currency` style rounds the *display* to the currency's fraction digits, but the underlying number keeps its full precision. A malformed `options` (for example `style: 'currency'` with no `currency` code) throws when the formatter is built — deliberately loud, so the misconfiguration surfaces in development rather than silently showing a raw number.
 
 ## Tree-shaking
 

--- a/packages/components/src/NumberFormatter/component.tsx
+++ b/packages/components/src/NumberFormatter/component.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react'
+import { type CustomComponentProps } from 'json-edit-react'
+
+export interface NumberFormatterProps {
+  // Options forwarded verbatim to `Intl.NumberFormat`. Covers decimal /
+  // currency / percent / unit styles, compact & scientific notation,
+  // grouping, sign display, fraction & significant digits, and rounding.
+  options?: Intl.NumberFormatOptions
+  // BCP-47 locale tag(s) for `Intl.NumberFormat`. Omit to use the runtime's
+  // default locale.
+  locale?: string | string[]
+}
+
+/**
+ * Display-only formatter for number values: renders each number through
+ * `Intl.NumberFormat` (thousands separators, currency, percent, …) while the
+ * stored value is left untouched. Editing is delegated to the node's standard
+ * number editor (the definition sets `showOnEdit: false`), so the raw,
+ * unformatted number is always what you edit.
+ */
+export const NumberFormatter = (props: CustomComponentProps<NumberFormatterProps>) => {
+  const { value, setIsEditing, canEdit, getStyles, nodeData, componentProps } = props
+  const { options, locale } = componentProps ?? {}
+
+  // Stable across renders while `componentProps` is (it's fixed in the
+  // definition), so the formatter isn't rebuilt for every node on each render.
+  // A malformed `options` (e.g. `style: 'currency'` with no `currency`) throws
+  // here — deliberately loud, so the misconfiguration surfaces in development.
+  const formatter = useMemo(() => new Intl.NumberFormat(locale, options), [locale, options])
+
+  // Only ever rendered in view mode (`showOnEdit: false`). A non-number can't
+  // reach here past the guard, but fall back defensively rather than throw.
+  const displayValue = typeof value === 'number' ? formatter.format(value) : String(value)
+
+  return (
+    <span
+      onDoubleClick={() => canEdit && setIsEditing(true)}
+      className="jer-value-number"
+      style={getStyles('number', nodeData)}
+    >
+      {displayValue}
+    </span>
+  )
+}

--- a/packages/components/src/NumberFormatter/definition.ts
+++ b/packages/components/src/NumberFormatter/definition.ts
@@ -1,0 +1,28 @@
+/**
+ * A display-only number formatter: renders number values through
+ * `Intl.NumberFormat` (thousands separators, currency, percent, …), edited as
+ * the raw number. High polish-per-byte for dashboards and pricing data, with
+ * zero dependencies (`Intl` is built into the platform).
+ */
+
+import { type CustomNodeDefinition } from 'json-edit-react'
+import { createDefinitionFactory } from '../_common/createDefinitionFactory'
+import { NumberFormatter, type NumberFormatterProps } from './component'
+
+// The condition doubles as the guard: consumer `condition` overrides are
+// targeting, ANDed with this by the factory; replacing it requires the
+// explicit `guard` override. The guard matches *every* number, so narrow with
+// a `condition` (e.g. `byKey(/price|amount|total/i)` from
+// `@json-edit-react/utils`) or unrelated numbers — years, IDs, ports — get
+// reformatted too.
+const NumberFormatterDefinition: CustomNodeDefinition<NumberFormatterProps> = {
+  condition: ({ value }) => typeof value === 'number',
+  component: NumberFormatter,
+  showOnView: true,
+  // A display decorator, not a new type: editing falls through to core's
+  // standard number editor (so the raw number is what you edit), and it stays
+  // out of the Type selector menu (`showInTypeSelector` defaults false).
+  showOnEdit: false,
+}
+
+export const numberFormatterDefinition = createDefinitionFactory(NumberFormatterDefinition)

--- a/packages/components/src/NumberFormatter/index.ts
+++ b/packages/components/src/NumberFormatter/index.ts
@@ -1,0 +1,2 @@
+export * from './definition'
+export * from './component'

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -13,6 +13,7 @@ export * from './Image'
 export * from './ColorPicker'
 export * from './ErrorIndicator'
 export * from './AutoType'
+export * from './NumberFormatter'
 
 // The definition factories' override surface; the factory builder itself
 // (`createDefinitionFactory`) stays internal

--- a/packages/components/test/NumberFormatter.test.tsx
+++ b/packages/components/test/NumberFormatter.test.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { JsonEditor, type CustomNodeDefinition, type JsonData } from 'json-edit-react'
+import { numberFormatterDefinition } from '../src/NumberFormatter'
+
+// A `locale` is passed to every definition so the expected output doesn't
+// depend on the machine's default locale.
+const usd = { locale: 'en-US', options: { style: 'currency' as const, currency: 'USD' } }
+
+const Harness = ({
+  initial,
+  defs,
+  onData,
+}: {
+  initial: JsonData
+  // Mirrors core's `customNodeDefinitions` prop type (permissive `any`
+  // componentProps), so a typed definition assigns.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defs: CustomNodeDefinition<Record<string, any>>[]
+  onData?: (d: JsonData) => void
+}) => {
+  const [data, setData] = useState<JsonData>(initial)
+  return (
+    <JsonEditor
+      data={data}
+      setData={(d) => {
+        onData?.(d)
+        setData(d)
+      }}
+      customNodeDefinitions={defs}
+    />
+  )
+}
+
+describe('NumberFormatter — display-only Intl formatting', () => {
+  test('formats a number as currency', () => {
+    render(
+      <Harness
+        initial={{ price: 1234.5 }}
+        defs={[numberFormatterDefinition({ componentProps: usd })]}
+      />
+    )
+    expect(screen.getByText('$1,234.50')).toBeInTheDocument()
+  })
+
+  test('applies locale grouping with no options', () => {
+    render(
+      <Harness
+        initial={{ count: 1234567 }}
+        defs={[numberFormatterDefinition({ componentProps: { locale: 'en-US' } })]}
+      />
+    )
+    expect(screen.getByText('1,234,567')).toBeInTheDocument()
+  })
+
+  test('percent style scales the stored fraction', () => {
+    render(
+      <Harness
+        initial={{ ratio: 0.5 }}
+        defs={[
+          numberFormatterDefinition({
+            componentProps: { locale: 'en-US', options: { style: 'percent' } },
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText('50%')).toBeInTheDocument()
+  })
+
+  test('only formats numbers matching the condition', () => {
+    render(
+      <Harness
+        initial={{ price: 1000, year: 2026 }}
+        defs={[
+          numberFormatterDefinition({
+            condition: ({ key }) => key === 'price',
+            componentProps: usd,
+          }),
+        ]}
+      />
+    )
+    expect(screen.getByText('$1,000.00')).toBeInTheDocument()
+    // `year` isn't targeted, so it stays a plain number (no grouping/currency).
+    expect(screen.getByText('2026')).toBeInTheDocument()
+  })
+
+  test('edits the raw number, and re-formats the committed value', async () => {
+    const user = userEvent.setup()
+    const received: JsonData[] = []
+    const { container } = render(
+      <Harness
+        initial={{ price: 1234.5 }}
+        onData={(d) => received.push(d)}
+        defs={[numberFormatterDefinition({ componentProps: usd })]}
+      />
+    )
+
+    // Entering edit mode shows the standard number editor with the raw,
+    // unformatted value — never the "$1,234.50" display string.
+    await user.dblClick(screen.getByText('$1,234.50'))
+    const input = screen.getByDisplayValue('1234.5')
+
+    await user.clear(input)
+    await user.type(input, '9999')
+    await user.click(container.querySelectorAll('.jer-confirm-buttons > button')[0])
+
+    // `setData` receives a plain number, not a formatted string…
+    expect(received.at(-1)).toEqual({ price: 9999 })
+    // …and the new value is re-formatted for display.
+    expect(screen.getByText('$9,999.00')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- New `NumberFormatter` component in `@json-edit-react/components`: display-only node that renders numbers through `Intl.NumberFormat` (thousands separators, currency, percent, compact/scientific, units, rounding), edited as the raw number. Zero deps — `Intl` is built into the platform. Addresses option 6 from #355.
- Uses the `createDefinitionFactory` pattern: guard matches every number, so consumers narrow with a `condition` (e.g. `byKey(/price|amount|total/i)` from `@json-edit-react/utils`) that gets ANDed with the guard.
- Demo (`custom-component-library`): new "Number Formatting" block with a locale-picker enum driving 6 differently-configured formatters (millions/currency/percent/units/compact/rounded), showcasing per-locale currency rules and live re-derivation as the locale changes.

## Test plan

- [x] `packages/components/test/NumberFormatter.test.tsx` — 5 tests (currency, locale grouping, percent scaling, `condition` targeting, edit-round-trip commits raw number and re-formats display). All green.
- [x] `pnpm lint`
- [x] `pnpm compile`
- [ ] Manual: switch the locale in the demo's "Number Formatting" block and confirm every field reformats; double-click any field and confirm you edit the raw unformatted number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)